### PR TITLE
Concentration and PH notebooks: Switch to http for Epcor data

### DIFF
--- a/Science/ConcentrationAndPH/concentration-and-ph.ipynb
+++ b/Science/ConcentrationAndPH/concentration-and-ph.ipynb
@@ -625,8 +625,8 @@
    "outputs": [],
    "source": [
     "# same code from investigating electrical conductivity notebook\n",
-    "url_ELS = \"https://apps.epcor.ca/DAilyWaterQuality/Default.aspx?zone=ELS\"\n",
-    "url_RD = \"https://apps.epcor.ca/DAilyWaterQuality/Default.aspx?zone=Rossdale\"\n",
+    "url_ELS = \"http://apps.epcor.ca/DAilyWaterQuality/Default.aspx?zone=ELS\"\n",
+    "url_RD = \"http://apps.epcor.ca/DAilyWaterQuality/Default.aspx?zone=Rossdale\"\n",
     "table_RD = pd.read_html(url_RD, header=0)\n",
     "table_ELS = pd.read_html(url_ELS, header=0)\n",
     "qgrid.QgridWidget(df = table_RD[0])"


### PR DESCRIPTION
Fixes #72.
>     Within the past few months, Epcor has apparently stopped serving this
>     data via https. At this point we're not sure if they're aware of it,
>     but for the moment switching to http solves the immediate issue.