### PR TITLE
Ignore deleted files in tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ test_modified="$(git diff --name-only $TRAVIS_COMMIT_RANGE test.sh)"
 if [ -z "$TRAVIS_COMMIT_RANGE" ] || [ ! -z "$test_modified" ]; then
     notebooks=($(git ls-files *.ipynb | grep -v \.ipynb_checkpoints))
 else
-    notebooks=($(git diff --name-only $TRAVIS_COMMIT_RANGE | grep \.ipynb$ | grep -v \.ipynb_checkpoints))
+    notebooks=($(git diff --name-only --diff-filter=d $TRAVIS_COMMIT_RANGE | grep \.ipynb$ | grep -v \.ipynb_checkpoints))
 fi
 
 retval=0


### PR DESCRIPTION
When determining which notebooks to test, the script currently includes deleted notebooks which causes test failures when they're present in a diff since those paths no longer exist. This change filters the diff output to exclude deleted files.

Build failure can be ignored.