### PR TITLE
Fix docker bind mount permissions

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -16,7 +16,7 @@ fi
 retval=0
 
 for notebook in "${notebooks[@]}"; do
-    docker run -v "$script_dir:/notebooks" callysto/pims-r py.test --nbval-lax "/notebooks/$notebook"
+    docker run -u "$UID" -v "$script_dir:/notebooks" callysto/pims-r py.test --nbval-lax --disable-pytest-warnings "/notebooks/$notebook"
     [ $? -ne 0 ] && retval=1
 done
 


### PR DESCRIPTION
~~Opening PR to test changes to fix failures when notebooks try writing files. Not ready to merge yet.~~

This fixes the Docker permissions issue where notebooks attempting to write files caused tests to fail. Instead of bind mounting the directory from the host, the repo is first copied into a Docker volume, chown'd to the correct user and then mounted by the test container. I've also disabled warnings in pytest to make the output more readable for authors and reviewers.