### PR TITLE
Fix links in multiplication-division-fractions notebook

### DIFF
--- a/Mathematics/multiplication-division-fractions.ipynb
+++ b/Mathematics/multiplication-division-fractions.ipynb
@@ -33,7 +33,7 @@
        "    $('div.input').hide()\n",
        "  });\n",
        "</script>\n",
-       "<form action=\"javascript:code_toggle()\"><input type=\"submit\" id=\"toggleButton\" value=\"Show Code\"></form>"
+       "<form action=\"javascript:code_toggle()\"><input type=\"submit\" id=\"toggleButton\" value=\"Show Code\"></form>\n"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -148,22 +148,26 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAUQAAABZCAYAAABG1V03AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAAaFJREFUeJzt3cFt3DAQQNFhEMBKBUn/1WUr2PXFyuUXEC8Sy6DfuxPU6PDnyHWe5wAw8+3qDwD4LAQRIIIIEEEEiCACRBABIogAEUSACCJABBEggggQQQSIIAJEEAEiiAARRIAIIkAEESCCCBBBBIggAkQQASKIABFEgAgiQL5fdfFaP37PPH5edf//9vJyvL2+PrZdOMdxvD0ee86382wzX2K+2/1+//XM2XWe57/+nr+7eK1z5pq7P8aaq/7tR1hr3/l2nm3my8y3njm77ZYAeC9BBIggAkQQASKIABFEgAgiQAQRIIIIEEEEiCACRBABIogAEUSACCJABBEggggQQQSIIAJEEAEiiAARRIBc9i7zzHGbWVu/y7zW2nbhHMe+8+0828yXmO/27NnL3mUG+Gy23RIA7yWIABFEgAgiQAQRIIIIEEEEiCACRBABIogAEUSACCJABBEggggQQQSIIAJEEAEiiAARRIAIIkAEESCCCBBBBIggAkQQASKIABFEgAgiQAQRIIIIEEEEiCACRBABIogAEUSACCJABBEgfwAIKjcftPNWxgAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAASUAAABECAYAAADHuCM8AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAABcElEQVR4nO3dMW4TQBRF0T8oUoYVkP2vjqzAThNTICGK4NJcj85pp5nX3Pav2+02ABXf/vcHAP4mSkCKKAEpogSkiBKQIkpAiigBKaIEpIgSkCJKQIooASmiBKSIEpAiSkCKKAEpogSkiBKQIkpAiigBKaIEpIgSkPJy73Gt7z9nrj8e9ZlHe33dnx8f12PDvPf+vF7te0Ynb5uZ2Xu/Xy6Xt6/e1r0TS2ut28zJJ5jWnHxiai37ntXJ22b+7FtfvR1bYuA5iRKQIkpAiigBKaIEpIgSkCJKQIooASmiBKSIEpAiSkCKKAEpogSkiBKQIkpAiigBKaIEpIgSkCJKQIooASmiBKSIEpBy9+7bzH6fWUfffVtrHRvmve17Vidvm/l99+1fb3fvvgE82rElBp6TKAEpogSkiBKQIkpAiigBKaIEpIgSkCJKQIooASmiBKSIEpAiSkCKKAEpogSkiBKQIkpAiigBKaIEpIgSkPILjkM29WMo3XMAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f53ff723518>"
+       "<Figure size 360x72 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAUQAAABZCAYAAABG1V03AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAAX9JREFUeJzt3TFqAzEQQNFVCFg+QXL/08UnsNNYaf4BwmZhg3mvH6Tqg4pBY621AbBtb2dfAOC/EESACCJABBEggggQQQSIIAJEEAEiiAARRIAIIkAEESCCCBBBBIggAkQQASKIABFEgAgiQAQRIIIIEEEEiCACRBABIogAeT/r4Ot1fD0e28dZ5wOvac7tdr+vzz2zY6119H1+d/A47WjghY2xbWutsWfWkxkggggQQQSIIAJEEAEiiAARRIAIIkAEESCCCJDTdpnnvDzH+BZk4FBzXp57Z0/eZbbMDBxrjGGXGeCvBBEggggQQQSIIAJEEAEiiAARRIAIIkAEESAn7jLP2xjDv8zAoeact72zPkcGiCczQAQRIIIIEEEEiCACRBABIogAEUSACCJABBEggggQQQSIIAJEEAEiiAARRIAIIkAEESCCCBBBBIggAkQQASKIABFEgAgiQAQRIIIIEEEEiCACRBABIogAEUSACCJABBEggggQQQSIIALkB+7cJewf6WgjAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAASUAAABECAYAAADHuCM8AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAABU0lEQVR4nO3dMUoEQRBA0SkRbE+g9z+dewI1cUwNdkeRRb/4XlpJRx86KGr2fd8AKm5++wEAH4kSkCJKQIooASmiBKSIEpAiSkCKKAEpogSkiBKQIkpAiigBKaIEpIgSkCJKQIooASmiBKSIEpAiSkCKKAEpogSk3B4N7+/n6eVle/ipxwD/w1rb6fl5fzw3m6MTSzOHY4Bvmdm2fd/n3Mz3DUgRJSBFlIAUUQJSRAlIESUgRZSAFFECUkQJSBElIOVw922tu7eZV+ECrmqtu7dLsy/svll+A65rZuy+AX+DKAEpogSkiBKQIkpAiigBKaIEpIgSkCJKQIooASmf7L6t08y4+wZc1VrrdGnmsBuQ4vsGpIgSkCJKQIooASmiBKSIEpAiSkCKKAEpogSkiBKQIkpAiigBKaIEpIgSkCJKQIooASmiBKSIEpAiSkCKKAEp7740JcJfHUOxAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f53ff723be0>"
+       "<Figure size 360x72 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -204,12 +208,14 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAUQAAABZCAYAAABG1V03AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAAdVJREFUeJzt3UFu2zAURdH/iwJiV5Duf3X1CuJMxEzeAmq3MQPqnLkgPQ8uR4R7zlkAVP1Y/QEA34UgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAoQgAsTPVS/uX/2n7vW26v1f7Rh1ftz3PXDGqPO+6b6dt1VdYt/t/X3+fubZnnP+7+/5uxd3z1rz6tfoqkU/7Uv0xvt23lZ1lX2zn3l221MC4FGCCBCCCBCCCBCCCBCCCBCCCBCCCBCCCBCCCBDL7jJXHWf1x7ZBPo5R3ffVn/Flxth3387bqq6w7ziffXbtXebNLzOv+m1foXvffTtvq7rMPneZAf6FIAKEIAKEIAKEIAKEIAKEIAKEIAKEIAKEIALEwrvM41bV+/4v8zHO7t72wBlj3307b6u6xL7bs88uu8sM8N1se0oAPEoQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAUIQAeIT/+FKefhlhDQAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAASUAAABECAYAAADHuCM8AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAABoUlEQVR4nO3dMW4cMRBE0W7BwLROYN//dN4TaJXMKLLhYDWKvKoh3kuZsJKfEezjOAogxct3XwDgX6IERBElIIooAVFECYgiSkAUUQKiiBIQRZSAKKIERBElIIooAVFECYgiSkAUUQKiiBIQRZSAKKIERBElIIooAVFECYjy4+ywX/t33evnsy7zbNvU/n5fN8wztd/tu6SVt1VVzdTt7e349eisz75Y6u6jVv6BqatW/mGq7buslbdV/dl39KOzZUsMXJMoAVFECYgiSkAUUQKiiBIQRZSAKKIERBElIIooAVFO375VbXv1+7Lh2rap7vt3X+O/mbHvqlbeVlU1s+2fnX399m3xx29n+6+u276rWnlb1d993r4B+UQJiCJKQBRRAqKIEhBFlIAoogREESUgiigBUUQJiPLF27e5VfW6/75ts3f3smGese+qVt5WVTUzt8/OTt++ATzbsiUGrkmUgCiiBEQRJSCKKAFRRAmIIkpAFFECoogSEEWUgCiiBEQRJSCKKAFRRAmIIkpAFFECoogSEEWUgCiiBEQRJSDKB789Sk92dZbzAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f54389f8550>"
+       "<Figure size 360x72 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -242,12 +248,14 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJwAAACQCAYAAAD9egI2AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAAjFJREFUeJzt3UFu2zAARUGyKGD2BOn9T9ecoMnG6gW8cQA/KezMnpAFPGnzAXkexzGg8uPsH8D/RXCkBEdKcKQER0pwpARHSnCkBEdKcKQER0pwpARHSnCkBEdKcKQER0pwpARHSnCkBEdKcKQER0pwpARHSnCkBEdKcKQER0pwpARHSnCkBEdKcKR+nnXh+Wv+GR/j7azrv97tPsbnxg/0ej+Ov7+fPTXP+sbvnPMYO39eeI4xNr/B4zjms6c2fgK5IsGREhwpwZESHCnBkRIcKcGREhwpwZE6bUu9rXH/nPsGv9ZtfHw8vfx8G7fbun/l3Klb6s5/1TrnGDvf4Jy2VL4BwZESHCnBkRIcKcGREhwpwZESHCnBkTptS11r3OfmW+qc+26pa9lSL8WW+ti2bxiuSXCkBEdKcKQER0pwpARHSnCkBEdKcKRsqS9iS33MlvoittTHtn3DcE2CIyU4UoIjJThSgiMlOFKCIyU4UoIjZUt9EVvqY7bUF7GlPrbtG4ZrEhwpwZESHCnBkRIcKcGREhwpwZESHKkzt9T3OcfbWdd/tbVu9znntg/0Wuv9K+f2HjS5nG2fQK5JcKQER0pwpARHSnCkBEdKcKQER0pwpARHSnCkBEdKcKQER0pwpARHSnCkBEdKcKQER0pwpARHSnCkBEdKcKQER0pwpARHSnCkBEdKcKQER0pwpARHSnCkBEdKcKQER0pwpARHSnCkBEdKcKQER0pwpARH6h/Lxlcp/+didwAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAH4AAAB7CAYAAACy7jQ7AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAABy0lEQVR4nO3dMW7DMBAF0d0gADcnSO5/uugEsRvRfSzRnQ3vzGvZSBhWH5Cdc84Qz8erH0CvYXgow0MZHsrwUIaHMjyU4aEMD2V4KMNDGR7K8FCGhzI8lOGhDA9leCjDQxkeyvBQhocyPJThoQwPZXgow0MZHsrwUIaH+lwd5lf+xiW+n/Uwzzf2iGvjy1/bnH8/Rye5+j4+M2d0/nw+I6L5C8458+ik8W3XiuGhDA9leCjDQxkeyvBQhocyPJThoZZb/ajYr9n3clSNuFwOF80Wxqj97OzhVt/5p24zIzq/YKZbvf4xPJThoQwPZXgow0MZHsrwUIaHMjzUcquvij2bb/WZfbf6Krf6Q271wjE8lOGhDA9leCjDQxkeyvBQhocyPJRbvVv9waFb/Vtzq9cdw0MZHsrwUIaHMjyU4aEMD2V4KMNDudW71R8cutW/Nbd63TE8lOGhDA9leCjDQxkeyvBQhocyPNSjrX7L7PvfslVjz8y2l7+qtrOz3mO8TrW97VozPJThoQwPZXgow0MZHsrwUIaHMjyU4aEMD2V4KMNDGR7K8FCGhzI8lOGhDA9leCjDQxkeyvBQhocyPJThoQwPZXgow0PdANBfVv9HtcufAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f53fd615c18>"
+       "<Figure size 144x144 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -403,25 +411,10 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "557831857c504b548a93fe6b48d5b962",
+       "model_id": "abc57dd558004ccbaa19132ae91e37d9",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>IntText</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
        "IntText(value=0, description='a =')"
       ]
@@ -463,25 +456,10 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ab3c1ebc46e34857bf3627dcdbcadce9",
+       "model_id": "26304db4379f4602a8535ed5ca8705a1",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>IntText</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
        "IntText(value=0, description='b =')"
       ]
@@ -525,25 +503,10 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2bfa6693b9704b1fbc6a1e78a1a91d7a",
+       "model_id": "fe38df0847ec487ebc2058134a26fe96",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>IntText</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
        "IntText(value=0, description='c =')"
       ]
@@ -580,25 +543,10 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "73315ee7e9cb48e594e01d8f112cc5eb",
+       "model_id": "b949f82ed5f746d89b46efa4bd658252",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>IntText</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
        "IntText(value=0, description='d =')"
       ]
@@ -718,11 +666,20 @@
    "outputs": [
     {
      "data": {
+      "image/jpeg": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAUDBAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIChALCAgOCQgIDRUNDhERExMTCAsWGBYSGBASExIBBQUFBwYIDgkJDxUSEhASEhUVEhISFRUSEhUVEhUSEhISEhIVEhIVEhUVEhISEhIVEhISEhUSFRUSFhIVEhISFv/AABEIAWgB4AMBIgACEQEDEQH/xAAdAAEAAgIDAQEAAAAAAAAAAAAABQgGBwEECQID/8QAThAAAQQBAgIECwMIBwUIAwAAAQACAwQFBhESIQcIEzEUFSI0QVFUdJKz1AkyYSM2QlJxgZG0JDNDYnJ1tRY1U4OxJkRzdoKh0fAlY4T/xAAbAQEAAwEBAQEAAAAAAAAAAAAAAQIDBAUGB//EAC0RAQACAQMCBQMEAgMAAAAAAAABAgMRITEEEgUTQVGBFDJxBiJhkSOxQlJy/9oADAMBAAIRAxEAPwCmSIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICKXt4ZkUkkT71QPje6NwDbxHExxa7YirzG4K/LxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lTxdD7fU+C99KgjUUl4uh9vqfBe+lX61MMyWSOJl6oXyPbG0Ft4Die4NbuTV5DchB+WqPPrvvdn5z1GqS1R59d97s/Oeo1AREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQFJaX8+pe91vnMUapLS/n1L3ut85iBqjz6773Z+c9RqktUefXfe7PznqNQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBSWl/PqXvdb5zFGqS0v59S97rfOYgao8+u+92fnPUapLVHn133uz856jUBERAREQEREBERAREQEREBERAREQERchBwi5ITZBwi5AQoOEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAUlpfz6l73W+cxRqktL+fUve63zmIGqPPrvvdn5z1GqS1R59d97s/Oeo1AREQEREBERAREQEREBERAREQFyuFyEH70qj5nBkbS5x9AWV1tKwwtDrczWE/oE7OXZxTWY6kbBAM0m3Bv6A4d6w/I35Z3cUji7meRPco5cPfk6i0xWdKx6+rK/FuK/4g+NcHAUJeUNhjT/AHnelYWV+lRry4Bm/ETsNk0T9Neu/fPylc1p6etu4jjj/Xb3KF2Ww8WyaAMitPEjJWk8LncRbsPV6Fg2UawTPDPu8R2/iphbps85Jms+nr7uquFzuuEdYiIgIiICIiAiIgIiICIiAiL9I4y7uBP7FMRqRGr80X09u3LuXCgcIiICIiAiIgIiICIiAiIgIiICIiApLS/n1L3ut85ijVJaX8+pe91vnMQNUefXfe7PznqNUlqjz6773Z+c9RqAiIgIiICIiAiIgIiICIiAiLkFBwvuM7EH8V6GYnqmaOkrwSvgv8UkMT3Hw+QDiexrnHu5cyuw/qj6LI2EV8b+kZB+4/Zu0hBSvL0DfqQmu4ExsaHN3A5hYRdx80JIewjZXX1h1Oo4Y3S6dzFmOdoJbWyvZywynvDBYrRMdD+0xv8Ax9arPqSxexVyXGZ2i+vZhIbJG9rd9j917JGEtlicOYe0lpHcVDz60zdPGlY7o1+WttlmulcaytCblgDlv2bT6T+iVvzqm9D+ndQ2L96+x1mKo2uyGiJpImcc/aF08xhc2RwHZBrQHAbl+4Pk7YL10NJ1MFnIKGPe5tObHw2xWc9z3VXvnsQmLjdzdGRA1zeIl3lO35cO7lpabdRSO3aJ599mnMrmpZ5nS8RHM7fgO5RbzvzPpXBTdS6qUrSNIcIiuT1PegfTea0+7K5aE5CxYsWYGxizPAykyAhgaG1pGk2Hf1nE8nyXx7Acy4spsizbp10pXweosriqkzp61OwGQyPLXPDHxRzCKRzeTpI+0MbjsNzGeQ7lhKAiLe3Uw6McVqXMW48s4ywUaYstotldC6258zYuN74yJPB4+IcQYQeKWLc7bhwaJRWF67XRVh9NX8a/Dh0EWRhsvlpGV8wrurvhaJI3SuMgik7YjZxOxhdsduQr0gIiICIiAiIg5CmtMRcUnr2UIsn0gzlI71M3W/T11s6Omr3XQmW/rZP8R/6rprt5M7yPP94rqLK/3SyyfdIi7eHx81uxBUrxmWxZmirwRNIDpJpntjijBcQAXPc0c+XNXr0x1ZtG6exjbmqp2WpWhnhNm3clpUIpnjbsazIZI3SDc7DjLnOLdwG/dFVFCUW0OsvX0zFmuz0m6N2NFSEymKW1NF4a587pRHJacXOb2Rg+6S0Hcd4IWr0BERAREQEREBERAREQEREBSWl/PqXvdb5zFGqS0v59S97rfOYgao8+u+92fnPUapLVHn133uz856jUBERAREQEREBERAREQEREBERB6pdLn5kZr/yxe/0yReVy9Uelz8yM1/5Yvf6ZIvK4IN89WXp/yeCyVWnkLk1rCWJWQWIrUrpvAmyEMbarPkPFC2NxDnMB4XN4/J4tnCzfXa6MIc1hRk4mNGQxBEjZByMlCSRgtwvP6TWA9s0nfh7N4G3G7fzsDdzy/H/ovVbpEeWaMyjrG/G3TF0y/rcYxUhf/wCriB/eittdJiOVPugHSOXydy1X03lWYmxjoIZJ7DnTt7Zlh729j/RweNodFuWvG33T3jl0OlboztS59mJyOShkys8lNk2SldYljJuNa2F8zpB2pAJYzfuaNvQFm32bchfkNQucdyalEk/86woPraWXM15aaCQH4+gORIIPYnYg+gqumjhydPGLH3RzG/592FdOXVvy+lcfHk57VS7VM7a8xqicPgdIHGJ72ysAMTnNLeLfk5zBt5S0mvTmu1muNDzV5Cx1i7j5KspcPJjy1Tk2Ut7w0XIY5QP1XN9aof1d9BOzeqsfi54j2MVkz5GN7eTa1I9rYilae7jcwQ/tlCs762i0RMerNcp1XMpS0/Jn8hksfTiioeHSVXiw6dnGwOhquPAGeEvc+OPh32D37bnvXe6rPRjqnL429dwGo3YWA25KFiBs9yMyvZXry9sBX8kPDJ2tbINnt2dsRutr/aL657ChQ0/DJtJekF+60Eb+CV3OZWY9p58ElkOeD66X7VMfZw/mxkf8+sf6fjUSo7rXEz0srkaM8vhNmpkLdSaZpe/t54LMkMkoL/LdxvaXeVzPFz5rffR51Os/kIGWMjaq4cStD2V5WSWbjQdyO3hYWshO3CeEyFw3Ic1pGygNMmoOlaQ3eDwcawyX9Z9wTeMbXghd6POew7+XduradbnBauu46qNKWZoTFLI+/BUs+B3rDSI+wMFnjYeBhExdGHtLuNv3ttkFXOlHqlahw9eW5Tlr5ivCxz5WVWyRXWsaC5zxVk3ErQB3Rvc7+6sI6tGjstms2a+FyZxN6tTluMtiSeMiOOWCJ8YNfyiHduN2nySAQd91I57pa13jKdzBZS5k4mW4XwyMykDzdbC8lkvY2rTO37N7eJhPE4bE7bb7rMfs7fzrtf5Hc/m8egwPrQaPzGFzUcGcypzF2zQiueFGSeThifZtQsgHb82Na6B5DWgNAeNgse6J+i7M6nsurYmqZBHwmxZlPZVKrXfdM85B2cdjsxoc9wa4hp2O25vtGh/2poHbl/s/V/1HKqzeisfBobQnbMgjM1DEvyNpm5aLWTkriSQSS7cXC6csiDiNwxrBtyAQV8h6kWTMXE/O0Gz7f1bath8W/q7Yua7b8eBaR6ZOhjO6UfH4zgY6tM7ggvVXOmpyv2LuyMha10U3CCQyRrSQ1xG4aSPvI9O2rprpvnP5KOXj42xQ2HxU2cyQwUWnwcxjfbZzDvsN91fPo7vQa+0TE7JxMJydSarcAaOGO3WlfB4VC3mI3CaFk7P1SW+pBQDoN6M7Oq8m7F1bMFWVlWW2ZLAkcwtifEws2jBPETKP4FbBb1UNTuzM2KjFUwQRwzPyz3Sx0OCcEtYwuj7SWwOF4MbGnbYEkBzSZnqC031ta3K8oAlgxmRhkA7g+K3UY8D8OJpWy+vj0s5vDWqOJxVt1CK1TNuxYr+RbeTNLC2Jk/fBGBFxbs2cSe/YbEME1N1K81BWdLRylG/YY0u8FdHJUMhA34IZnucwuPo4+AeshVhyVKatNNXnjfDPBLJBNFI0tkilieWSRvaebXte0gj0EK53UB6S8xk7mUxWTv2sjFFTZdryXJnWJoXNnbDKwTy7yvY8TsPC5xDey5AbnfVPX4xMNbWMskTQ03cfTtzbdxm/K1S7b0EsrMJ9Z3PeSgr+tq9BnR/lM/JPWxlYyuawdrO89nVrh2/CZ5yCG77HZoBceF2zTsVqwr0z6NcVW0VoUWBA0zVMU/LXg3k6zffWE8jXP2BPl8ELSe5kbB6FpjvNJ1hrhyzjnWGgW9SbKPjL5M7QZORv2TKth8QPq7Yua7b8eD9y0h0y9C2d0o5hyUDJKsruCG/Uc6am9+xPZue5rXwy7AkNka0u4XcPEGnb9Mv056unvG8c/kopePjENezJDTZzJEbaTT2BjG+2zmu32G+6vb0V5SHXmiojlYY3OyNaxTvta0cIs15XweExN7o5OKOOdoH3HEbd26pPO7O2uu6rXUy6HMjkL+N1PHLR8XY/JyMmhklnbcdJXha/iijbAY3AOniI3kH3T+G9j+t50TZjVtXF1cXYowMqz2LFkXZp4mve6OOOuYxBBJxOaDP37bcfLfc7VW6qOey+K1hRwbb1iGpJk54b9KOV3gs00EU0T3GJ3k8W8LBxAAkMbv3DaxfX01llcNjcRNir9mhJNdmjlfWkMZkYK/EGv27wHDdQhS7pi6OL2lsiMZkJastg14rPFTklkh7OYyNaOKaKN3HvG7ccO3McysLUxq7VGRy9jwrJ3J7tkRti7aw/jk7NhcWM3/VBe74iodAREQEREBERAREQEREBERAUlpfz6l73W+cxRqktL+fUve63zmIGqPPrvvdn5z1GqS1R59d97s/Oeo1AREQEREBERAREQEREBERARFyEHqj0ufmRmv8Ayxe/0yReVy9FMV1rNFsrQRSXLRLIIo3jxfZI3bG1rh93YjcFfbutVoUDcTzkj0DGTb/u3YAgq71XugzJ57J07lqnNXwleVk9izYYYm22xEPbVqNeN5zI4Brnt8lreM8XFwtdZ/rx6/ZjNOyYqF29/NA1mxt74qTXNNyZ47gxzQIR6zM7bfgdthHSH11KDInswOMsT2CC1ljJcEFeM7cpBBBI6Scb/ol0X7VWLN9KN/JWJbeUeLlmV27pJGjkNyWxxsHkxRNB2DGgAKJZZbWrGtY1lv37NmNzb+oA4Ef0Oief/jWFFdbjHf8AbS3bkIbFHRoAE+kiHchdPqo9NmGwVrJy5Zzq0divWjgMFaSZz3xyzOkDxEDwgBzdt/WVgnWq6Ramf1BNdxU8slF9WrG0vjfA4yRRlsm8b9jtv6UZXrkzYtJ2mefw3Z1DOkNrspl8E9+0dwDJUgTy7eBrIbbG+tz4BA/b1VX+tbq6KuiqLEap1Xm+zaxmSlrikdtiyOeJlzJ89tgH3djsOW0I/d52dGOqpcHmMbloeLjo24pnNaQDJCHcNiDd3ICSB0sZ7uUhVyumnrVafsYHJVsLZsyZK1XdVg46s8AjFgiKabtXjZr2Qukc3+8GqXRSsUrFY9FVOsdrj/aHUuSyDX8dbtfBqPPdopVd4oHN9Qk4XS7euZytx9nD+bGR/wA+sf6fjVQNWy6mvTfp7TOEuUctYnisTZWW3G2KrNO0wvqUoWkujBAdxwyDb8B60WV/6cPzo1L/AJ9mP9RsLbHRn1tNSYhkdXIRw5mCAdn/AEwyQ5BoYOEMNxm/GRsd3SxyPPpKwKrr6lU1ta1GKTMpS8eZHIwVrBdB2kc9qeWtMN2ns5mdpHIA5pAcwbj1WcyvTH0VaiLbmbpNiucIDjcxlh1k8PINfYxoeJmD0cTiB6gg2vj7GH6RdKdvPTfHWuRWWMFhkZs0LcJkhNivKOJoex7eJrxycOTm83MVU/s8B/2stdx//CXBuO47XMfzCy/pi60OIgw8mC0dUfBHJXkqi2IRRr1IJgRKaVdu0psODn+W4M4XO4vKK1J1PukHGabz89/KySQ1n4uxVa6KF87u2ksU5GjgjG4HDC/n+A9aDZ/2hcEbszUc7YPGFhDT/wD25DYfxVitetOptBWnUAZX5LANsVo2bcT5uwZYZXHPlIZI+z2Pc7cFUu643SPjdS5ypdxM0stWLEwVXmWKSAiwy5emcAyQAkdnPEeL8fwUr1Y+sfPpaLxZfryXsOZHSRiF7RaovkJdL4O2Qhk0L37uMTnM2c9zg7mQ69rd0RHtDS9otERHpCvjmEEg8iORB5EH0g+or0v6o2Jfh9EY518eDEx28jMJfJ7GvNNLYje/f7o8G7N5B7uJYTY6Y+iixN4ynq0XX3OEznzaelfaMo5iR8gqujfMCB5ZcTuBz5LUnWX60hztSbD4SCepj5/JuW5yI7VuMO3NeOKJxEFZ3COIlxc9p4SGjiDqM3HUayQua8yVwAtFqjlbIadt2ie9Vl2Ox23HEv3+0j/3/if8nH87aWveqFr/ABum9QSZDKySRVnY6zWDo4XzO7WWWs9g4IwTttE/n+AUl1zeknE6nyuPt4iWSaGvjvB5TLBJARL4TPLsGyAFw4Xt5hBl32bv5wZX/JnfztNRf2h/52wf5LT/AJm8oXqY9I2L01l79vKySxw2Mc6tEYYJLDjKbVeXYtiBIHBG7n+C/Drd6yo6mz8WQxRnlrMxtesXS15YHdtHPakeOCQAlvDKzn+J9SmImeExWZ4aR3XqDqTfUugZzQHayZPT3FXjYRu6wagcK/fsH9swxEb8juvNCLEzO/s3fvBVhOrH03X9LRnHXa0l/DvkdK1kbw21RkfzkdVEpDJYXu8owlzBxFzg4EuDr+Vf2a+Rf0hWyVjg4tcC1wJDmu5FpB2IcD3EH0L0o6m+IkxOise66DW7bwzIvEvk9nXmlfJDI/8AVa6sxkv7HjfY7hY5Z6TejC1P4xsUKjr7nCVz59OyvtOlHMPfK2q6N8oO3ll5PIc+5a36xXWCnzlObEYWGSnj7Dezt27DmstWoe59eKGMkV67xsHOLi5zSW7MG/E8q/smvT5bTxLU/V8ygvdIuOvNaWtuZm7aDXbBzRYFuYNOxIBAeO4lb++0n/3ThP8AMZ/5ZVu6E54MFqLE5W7Jw1KVl0s7omule1hglZu2NnlPPE9vIetbO66HTLgdT4/GV8RYmllq3JZphLWlgAY6DgaQZAA48XoCras1Z5Mdsc6Sq2iIqqCIiAiIgIiICIiAiIgIiICktL+fUve63zmKNUlpfz6l73W+cxA1R59d97s/Oeo1SWqPPrvvdn5z1GoCIiAiIgIiICIiAiIgIiICLt0cdNP/AFbC7bv2Xdbpu2f7J3/t/wDKaqWyVrzKI2TZTQ0xc/4Tv/ZftHpC4f7Mj+CjVSeoxR6wx/ZcrKodE2D948P7dl+8eif1rDW+vkp1ZT12CP8Akw4os2bpOq0+Xbj/AIFfoMFjW99hh/eVEyr9fi9NZ+GCFNlnzcTie7tm/wASsT1BViimc2F4ez0EJEtcXU1yzpET8oxERS6BERB28dV7V4Zvtv6VkDdLDl+UH8QsXa8juX6iy/8AWP8AFb470j7o1dGK+Kv3RqyhumIh96bb+C+xhabPvTb/ALgsTNh/6x/ivh0zj6T/ABWvn444q6PqcMcUZZkIqDInBh4n7cuXpWJSd5XHGfSSuN1hlyRedo0c2bNGSdo0cIi53WTB+1WYsPEO9STc9KO4qHQlXrktXhpXLavCXOfn/XI/gvk5yf8AXKiVyredf3W+oye6ROYnP6bl8nKzH9MrobL6AKjzb+6POye8u1JkJHDYuOy6bivvsz6l8FuyraZnlW02ty4REVVBERAREQEREBERAREQEREBSWl/PqXvdb5zFGqS0v59S97rfOYgao8+u+92fnPUapLVHn133uz856jUBERAREQEREBERAREQEREHco5CSH+rdt+9d1uorQ/TP8AEqHCboztipbeYTX+0tr9c/xK+X6jtH+0d+4kKH3X2yNzvugn9g3RXyMXtDafV40Rc1bnIcabU0FZkb7d+eM7yR1InMa4RcXkiZ75I42kghpkLiHcPCbea5i6M9Htr0MrjcY6eWHtI458ccvefEHFnbzTTRyPjDnteAXObuWv4R5J26vU06FzgIm5w5CO2M1iaT2wNqmI1hOI7Rb23bOEu3EGnYN34AfwXx1gOrHNqrNSZYZtlNrq9euyu6g6wWNgaQT2gss5FznO229KjRpWlY4hRbW+Qr2MnkZqDXQ0Zr9uWlDt2YhqSWJH1ohG0kR8MTmN4QdhtsoUvPrP8VYDof6uBzmUzWNnyZqDESuiZPHVbP4TwWrFYuMRnb2P9QHbbu+/t6FLaU6o+RuZvJ0Zbra+LxlhkAybq5Mt5z4IbIZVq9rsCIpmBz3P4WucAOMhwEorNbRrCtHF+J/ihd/9PNby6zvQXBpW3iKuOuWclLlu3YytJAwTslikrRRBjojtKZX2C0N4QQY+93Fyzzo46l2RtQsnzeSixrngO8DqxC5Ya0geTNMXthikB3GzO1Hdz7wC6p6K5OuupMWV3y4XLumsMbu2rkIWRsnI72ttQH8i4jfbiYQSRuWjcioGVx81WxNVsRuhsV5pa88Txs+KaF5jljePQ5r2kH9iDqot/dA/Vfy2pa8eQszsxOMlBMEssT57VpocAJIK3EwNgI4tpHvG+zS1rgd1t7L9SCkYf6JnrTLAHfZqRSwuPq4YpGOYD693beooKSBbuwHV6tWdHy6udkYoYmVrdqOiasjpJIqs0kHObtAGF5ic4eSRwlp9PL6031aM1Y1JY01as0qdmvQ8ZizxPsQWKfhEdZsldrA153keRtIGEcB325b3im6M99HDSrLTWHxQzGG52JLeMRNZJY7DtN/KfxO4OP8AS70HlxRpPlOzQSVfjqudEmlLGlK01rG4/IWrLJjkrFuKOaeGcPka+Fkj/LpNZGGbdmWEjZ+54tzpPpj6CXaJxsGRmysd9k96OkGMovrOa+SCxOHl5syAt2rEbbD73fyU90M9X+TVeEjyzdQWsbHefZhlpwVTJHIytYkhb2zhaYJgQzfZzeXFt+K2tWnZExO7qvTF5UTE7qy69qU6+VycGPk7ahDftxUpuIPEtWOeRleQSNJEgMQaQ79IHf0qDXZyUHZTTRb8XZSPj4ttt+zcW77eju7lZXog6n+UylaK7mLYw8UzWyR1OwM98xuG4M7HPYyo4gtIa4ucNyHNaRssXKrCiurqbqQwdkXY3Oytma0kMv1WOikcAdmmWu5roW77c+B+3qKqd0j6JyOn8hNjcpXNezFs5ux44p4Xb9nYryjlLA7hOxHMFrmkNc1zQGNorIdCvViGptOtzUeXdWnkdbZFUNISxmSvI+ONrpu3aQHlo3PDy4vTsso6MOphZtV47OdyJx75Gh4oVImzzxBwBDbFiR3ZslHPdjGvA/W9ACo67mPrte7ynBo/HkrC9YHqrXNPUpcrjbnjOhXHHbjkh7G5Vi3A7YBhcyxC3cl7hwFo2PCW8Tm6W6MtE5HUORhxeMjbJYm4nFzyWQwQsAMlixIGns4W7jnsSS5rQHOcAZrMQmsxHL8Oxps+8S4/gQvpl2m37rHE/iArd4TqR0hCPDc7afYI3JqVYYoGEj7oEznvkAPp3bv6gtT9NHVlu6aa24L0N/GOlbEZeHwa1FJJxFjJKznubI0hu3FG8nkSWtA3XRjvNp7axy7MWa1rRWsRu1RQvMkcGthaRv8AqhR2rYGMkHBsN27kD0FTU721mlkEe7vS/bmsYvxTOJe8O5+kg/8Awt89Ziukxu6uqia07ZjWffRHIvpwXyvPeQIiICIiAiIgIiICIiAiIgKS0v59S97rfOYo1SWl/PqXvdb5zEDVHn133uz856jVJao8+u+92fnPUagIiICIiAiIgIiICIiAiIgIiIOQu9jcnJB/VkD9oB/6roLkBETETyuH9nZnLVnI5mKaeR0MdGB8cJe7sWPdZdxPbHvwtedzuQOaxnr05nIQ6u7GpbtwtdjKTuzgszxM4i6cF3DG8DiIA5/gFOfZv1JGZLNPc0hrsfW4SR3/ANJd3f8A30qO68OXhqapkdwcVh2Mo7EgFrWh1jb9++6iWN7dtP2Rr6bMs+z4pWI7ucfZkc6WWpScQ4lz/wCvskvc4nckk9559663Xc6bc1jcq3BYmzLjooa0E9mzXIZZsSz7vaxkw8qGFjA37vCXOc7ckABfj9nTfksZLUMkrtz4JQ29QHbWTsFrXr7fnna9xx/yEhfFW1a/u5/hqPVutMtl5a82TyFq7NWjEUEtiVz5I2B5fs1/fvxHfiJ37ufILPsnrrXmsomURJlcpBCxsUkFCs5sMnLbjvGnGGyuI9Mx27+7c7wPV20bXz+psVirbiKtiaR9gNdwukhq15rT4WuBBaZBDwbtO4DyR3K5nWg6WJNBU8VjsFjKUfhbLPYl8RZTqx1TAHMjrQFnazOM4O5cNtgSH8XKWiH6jOldU4Z2RqZqnbqY2SGKakyxKxzIrLZHNlbDEJHOhL2P3cNgD2Q9K1T1l9FQXulCpjw09nmJsM62GHhPBJwV7T2kHkewgc7l6d/WtudTHpU1Pqe7k5cu8SY6vAxsL4qcMFdtx0jXGJszGB0kghJJYXHYOaT3jfW3Wf1AzFdKGIyMjuGKoMNLO4jfauJ5G2DsPT2LpEG8+uRrixprSzW4t3gk9yzBi68sP5N1ODsJpZHwcI/JuEVfsmkbFvagjYtBHnxgNYZShc8YU8hbr3eMPdZjnkEsrgd9pnFx7dp9LX8QIJBBBXoD13tGWs5pYPx7HWZsfchyIhhb2r7FYQzwTCENPluDJ2y8t9xC4AEkLzw0/hrWQsxU6Vea1ZndwRQQRukke78GtHcBzJ7gASdgEHfzuscpevzZSzesPyFg7y22PMMrvIEYaDDwhjAxrWhjQGgNAAXpD0r2JGdH16Vkj2St06x7ZWvc2QPFWMh4eDuHb89+9ebOstMX8PcloZKtJUuQ8PaQScJIDmhzHNcwlkjC0ghzSQV6SdKUT5ujy82JrpXP000sbGC9zgKTHHhDfveSCeXoCDzTyWdvWWCOzctWGBweGT2JpWhwBAcGyOIDtnEb/iV6K9Rb8yMb/wCPkf5+wvOGajMyKKZ8MrIZ+07GV0b2xTdk4Nl7KQjhk4XOAOxOxI3Xo91FvzIxv/j5H+fsIKmdVPSkWW13Cyw0SQUpruSkjcNw91V58HBHcQLL4HEHcEMI9K3x9oT0hX8bWxeJoWJKoyHhFi5LC90Ur4K5iZFXD2bObE98khdsRv2TR3Eg6N6o+pocZryLt3NZFfkvY0vcQA2Sy8urjc+l1iKFg/GQLcn2jejrdiviczXifLBSFmrdLGueYGTGKSvM8NHkw8UcrS87AF8Y/SQVy6tPSFfwWoMaa9iRlO1erV71Uvea88FmWOCR7ot+EzMa7ja/vBYOexINsPtDNKxWtOV8pwtFnF3omiTbdxq3N4JYtx6O28Gdz7uB36yqB1edH281qPE1q0L5GR3qti3IGOMdepBM2aeSV4G0e7I3NbxEcT3MaDu4K4n2hGpoqumYscXN8Iyl6EMjLtneD0z4TNMG7bua2UVmf84fsQTnUQ/Mqj73kP5uRUX6XtcZbK5m3Yv3rEz692cVh2jmRVWxTFsbasTCGwBoY3mwAkjckkkq9HUP/Mqj73kP5uReeusv95ZD363/ADEiD0l6uWVmz2hMbLknGzJao3qVl8pL3TxwWLmPDpnOJMkjoYWlzidyS4+lVp+zjy9ODN5OrM5jLdyjGKfFsHSCvKZLMMZPe8tMcnCO8QOP6KsP1MPzAw3+DK/6vkV51aSxmStWWjFV71i3APCWDHRWJbMIic3+kNFYGSMMcWeWNtiRzQXN613QbqXL5jx3jJm5OBkcIgxklhleaiY2xtk8EE5bC5r3sMxdxtfxOI2dsFXPpH1jqOExYrOeMojTJfDUyPa8UfHuztYzKN5WEBwa/dw23DTsSsw6OutlqnGPjr5ERZmBjxG+O2ww39m+SY2WoQD2u475WSEnfdWL682Ip3NGT37EIbapS0Z6LpBwzwyWbMEE0JIO+zoZX8TOY3iadt2AjXHmtj4bYuovi+1Q12pZfRt/BdnG5gzOEcgDg7l3Ad/pWKhT2l6ZL+0dyawcW57txz2W2LLe9t3Thz5Ml9JdDN1xHM9o7geS6BUhnZxJO9w7i5RywyfdLkzad86e4iIs2YiIgIiICIiAiIgIiICktL+fUve63zmKNUlpfz6l73W+cxA1R59d97s/Oeo1SWqPPrvvdn5z1GoCIiAiIgIiICIiAiIgIiICIiApPTksLJ2unG8YI3G26jQEUSrevdEws70BdM+J03buWJobM0ditHAxlcRbsLJeMud2r2jYjlyWMdYHXOH1RmTlWCxXYalesI5hHxgwmUl35Nzm7HtPX6Fopcbpo5adJ2U7K2nRZbqvdJOI0rayMpjs2vDoK8LWQ9i0tdDJK8ucZXtGxEgHL1LAutTqtmd1BLlIa89aGWtWiaywYzJvAzgcSYnObsT3c1qhjyDuDsQs21B+VxsT3d7eEb+nZETN8FqxM6xO2/KB0Nqe3hcjTylFzWWqUzZoi9pdG7YFr45Ggguiexz2OAIOzzsR3q4rut/pbIVGR5rT92eUbPfWNfHZCmJQNuJj7czD6Tsez35qkBXCl2ra1+uO+LLVPB8SynpysyWN+PriHwuXjY4RzCThbFDwO4CIWADnJu527eHTPWZ6R6uqc6crTgsV4TUr1+zs9n2nHD2nE78k5zeE8Y9PoWsEQWa6v/Wts4OnDi8xVlyVGswR1bED2tu1oWjZkBEvkWYmjYN3cwtA23cA0DZ2V65mnIWyy4/CZKS28H+vjoUmyO7wJJ4Jpnlu/p4SqLogzbpk6SshqnJHJZDs2uawQV68LA2KtWa5z2QsP35DxPe4veSSXnuGzRYXoI63FbF4mri87Ru2DQiZXrW6AgkfJXibwQsnhsSxhr2RhrONrjxBo3G+5NREQWN60/WFx2rKUGOpYiWJkFhtmO9dextmJwa9jo4YKznMa17XeVxPcDsPJ3a1wyLq6dZ3Eaa09UxFuhkp568tp7pa4qmIiezJM0N7WZrtw14B3HeFVBEHbv2+OxLMziZxzPlZ6HN4nl7eY7nDl3epWs6JOuRLVrMqaiozZDsmhjchUdG21KwANAs15S2OaTv3kD278t2k7uNSEQXlyvXO0/XgeMVhMi6Y7lsdhlGhAX9wc99aaZx2/wAPP8FUrpa6RsnqfIvyOTla5/D2cEEYLa9WEElsMDCSWt3JJJJLiSSSsPRBazq49ZrE6ZwFfEW6GRnmhntSukrCsYi2eZ0rQO1ma7cB2x5KsOeuNsW7NhoLWz2JpmtdtxBssjngO25b7OXRRBbfq/dZvFYHTePwc+OyVizVbdD5a/gnYu8JvWrTOAyztdyZO0HcDmCtU9Xfpes6LtWXjHQ3YLrYmWWuJhstbCXlhr2uF3C3eQksc0h3C37pG61JVmLHBw7wsnq5uGVoE8YJH6XrW2Klb8zo6cGPHfa06Sts7rWaKfKL0mm7zsk3YiwcdiXzB47trrrIlG3r4d1ozrEdO2R1iYqrK3gGLry9rFUa8zSzTAOYyxZm4QC4Mc4NY0AN7R3Nx2IwE2qA58AP7yvyfqCKMbRQhp9fetfIpG82bfTYq7zZ18fp7lxzODGft5/wK4zGUa1nYwDZg7z3E7d+6jMjlZJj5Tjt/D/ougSq2y1rGlP7RfqKUjtxx8jjuvlfS4K55cLhERQCIiAiIgIiICIiAiIgKS0v59S97rfOYo1SWl/PqXvdb5zEDVHn133uz856jVJao8+u+92fnPUagIiICIiAiIgIiICIiAiIgLkLhEGQaQFV73RWRsH7BruQDf2qQzGi5WnjrkSxnu4efJYi12ymsVqa1X5NeXN9RKidXHmxZot3Y5+JfH+zlv8A4T/hK+49LXHf2Th/6SpP/bmz+q1flNre0e7Zu/qKjdn3dZPpDu43RTmkPsyMYwcyDyOy/HWmYiLG1YOcbNtzyO5HpUDezdmbfjleQfRvyUaTupiFsfTZLWi+WddOIjgK4RFLuEREBERAREQEREBERAREQEREBchy4RB98ZXyXLhE1TrIiIiHO64REBERAREQEREBERAREQEREBSWl/PqXvdb5zFGqS0v59S97rfOYgao8+u+92fnPUapLVHn133uz856jUBERAREQEREBERAREQEREBERAREQc7puuEQc7rhEQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQFJaX8+pe91vnMUapLS/n1L3ut85iBqjz6773Z+c9RqktUefXfe7PznqOAQcL64Csv0X0eXslwycPg1Y/8AeJQfKH/6Y+Tpf28m9/Nbu0poqhjmbQwiWVzdnzztbJK7f7zRy2Yz+60D8d+9aUxWu+e8U/UvR+Hz2fff/rX0/M8R+N5/hWEhcLfeteimrbDpqJbUnO57PY+CyHb9Vu5h9HNu4/u+laa1DgLVCXsbcL4nfok82SAd7o5B5L293MH089lF6TTl1+GeN9J4lH+K37vWs7Wj49Y/mNUSiLnZUes4Rc7Ig4REQEREBERARfTGF3IAk7E7DmdmgucdvUACT+AXygIiICIiAiLnZBwiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICktL+fUve63zmKNUlpfz6l73W+cxA1R59d97s/OevvSMbX36LHtDmPuVWua4btc107A5pB7wQSF8ao8+u+92fnPX66L/3lj/fqn8xGpjlj1E6Yr/+Z/0t5TwV2aB1iCpYmrscWOkiifI1rmhpIIYCWgBzee2wBW4OrjJRFWyN4he7c9pxlglNbgZ2fBvzMPF2m/49/oX5dWzNs4LePe4CTtBbhB/Ta5jIpQPxaY4z/wAw+pfp09aHjdGMnUiAmEkcdljAAJu3e2KOXh/4vaOa0n0h+5+7z6r21ntnZ+deE+H/AEnT08Swf5Jis91J/qZrO+8c6TG8S1/0nwV583ZjxcfatcWbsqMMjXzho7YxMiB4vK7+H9LiWqOnnEy18VditwOimiFeQMlbwvYXzQ8LgDzaSxx/c4q5/R5pGvh6rWNaw2HNDrVjYcUkm27gHH7sLdyA31Dc8ySam9azMsyEWbsxniic6vHER3OjglrQtePW1xYXD/EnmaxMRxEL5vCfpOpwdTktpky56z2V4rEzrMa8zprET6bq+dAzQdU6cBAIOcxe4IBB/psPeCrU9ZDohtas19RqVx4PSr4KjLkrjWDhrxOyGUDWtG2z7UnA5rGn9RxPJhVV+gP86tN/55i/52FeiGrtfUP9oZNH3nyVH5fCsmpXYJjBK+WxLeqy1WTNIdDaDIWvicO88Y5HhDuR+kKvdafpTx1Ci3RGl44osfTAr5KzFwu7VzHcT6ccuxMh7Ycc02+737t324+LLOsXpi5ktBaGrYyhYu2TBi3dlTrPnlDPE2znubE0lsfEW7uOwG43KrX06dGF7SuVlx9oF8Dt5KFwN2juVd9myD0Nmbya9ne13raWudbfph6Ssppno/0nPiJI4LVylh6psPijndDE3FCZxiimaYzIXRtG72uABdy3IICkeqtLZLFSiDJULlCZwLmR268sDntB2L4+0aO0Zvy4m7hS+nOjHUWRibPRweVswPbxRzxUbBgkbvtvHMWcEn/pJVpenvKu1J0WYvPZBkZyEdivJ2sbQz8r4VNj53NDeTWyNAeWDluG8vJG376aqaj05g8JFmdfUdMsfAG0MY/D1L7wwO7bgsTvAkcWNmjY/byGeSOInmQprewV2C14DPTtQ3eNkXgcteaO12sm3Zx+DvaJO0dxN2btueIbd6ncR0Zaity2Ia2Dy0stR3BZjbQsh1eTha8RTBzB2UpY9rgx2ziHAgK13XBoxN1noOyGt7ae3UilkaNuNkGVpviG+/MA2Jdv8S7HXH6cc7pnN0Mfh5K9eI04clZL68M7rjpLNiHsJe1aTHDwVQC6MteeP7w2CCk2XxtinNJWt156tiIhssFiKSCaJxAcGyRSgOY7Yg7EekLqK232kOPhFvTt5sbW2LdS7FM8Dynx131ZIWuPp4Tal2/xKrmlMHYyd6pj6jOOzdsRVoW89uOV4YHPLQS2Nu/E523INJ9CC2v2f3RtC6tkdQZGKN0Vtr8PSZOBwSRSlrLzgHcnCR7o64257iZvpVbOm/Q0mnc9kcU/iMcExdUkcD+WpzDtasgceTj2TmtcRyD2PHoKvB0xdGGfGC09gNJGCGDEy1rM9qew2vJJYoFklV/AGEPc+0ZLL+QHGyPb07YT19Oj+e7hcdqV1dkWQx8cNbKxxOEjW17BG20gG8kcNx7mtPLybTidtuQU50tpbJ5WV0ONx9y/K3YvZUrS2DGHHZrpOzaRGwkHynbDkVxqnS+SxUogyVC5QlcCWx268tdz2g7F0faNHaM3/SbuFcfVGopdBdHOAm0/HBFczDaT7F8xsm2sXaDrs1jaQFk0vkCNgkBaGM7vJ2Wgdf8ATHqHWNLFYO7DWtT+HtEFmKtFDZu2puGCCIuG0ULt5iD2YYHdozcDh5himP6JNUWIu3h09mXxcIeHjG2tntI3DogY95QR+oCsOtV5IpHxSsfHLE90ckcjXMkjewlr2PY4bse1wIIPMEFegeFsZ3E5PC0M50hY5l2V1JviBmGrPjsxOc2ua7bw4JxJKWuayV4aS87gEclA5PRWPu9MO88UbmRYmLLmFzWmOe7DEytE57SPKLd2S/4oATvz3CtvRJ0X6iGWwd5+BywpNy2MlfO7H2REIRbge6Z3FH/UBm5Mn3dgeazv7RKNrdV1OFoA8RVCeEAf99yQ3O34AfwWaau6xGpWa9bhoJIquMizsGJdTkqQPdPCbcdaSy+d7TMHSNc57eBzQGuZyPMmf6adM1Mt0s6cpXmslrHDRzvgk5ssGpJmLUcLmnk9hkiYXNO4LWuB33QVHxnRlqKzUF6vg8tPUc0PbYioWXxyRkb9pGWs/Kx7c+Nu47+agcJhLl6YVqVS1csEPcK9WvLYmLYwTI4RRNLyGgEk7ctl6Ha41yylqTeXXuMxlOlJAyxpybExvc6IRxulZLddMJRNI13E17QGsBj8lwDuLAdE3sJb6WGXMDYgsV7mGs2LUlbfsfGBZIycgEAcbo44Hu273SOJ5koKk0OjnPz0jkYMNlJaIaZPCo6Nh0BjG5MrXhmz4gAd3t3A2O55LnBdG+oL9Y3aWFytqptuLFehZlieNyCYnMZtLsQd+Dfbbnsrjaa6aM1N0mv00ZIGYVk12hHTbXhHB4HRmsMsCxw9t2pkgA4eLgDXkBu4BXzkOmTN1+kyLTMcldmEZPWoikytC0cM2PjnE3b8PatkbJJya1wZwsA4e8oKV6e0jlci+aPH4zIX319u3ZTpWbT4OIua3tmwRuMW5Y8Di2+671FdXDYG9dseCU6dq3aPH/Rq1eaex+TBMn5GJpf5IB35ctjuroV9Qw6f6X7lZvDDV1BBVrztBDWeHWa0MsEu3plfbj4fxNt59KyzQHR7W0rn9c6quMMdKMSS0nc+dexDHlciYm78/wAuY4G7DfeKRo5HmHn9mcXZpTyVrleepZiIEtezDJBPES0OAkilAewlrmnmO5wXTUvrPUE+VyF3JWjvYvWZbMvMkNdK8uDG78xG1pDQPQGgKIQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBSWl/PqXvdb5zFGqS0v59S97rfOYgao8+u+92fnPXXxNt1eeGdoBdBNFM0H7pdE8PaDtz23aF2NUefXfe7PznqNRExFo0n1Wc6O+kutblhfXmdSyEbg5kb3hr+MD+wk+7KNt/J7yCd27Lf1HpoldAIb1Fk7g6N3awSmDjdFI2RpdG9jwHcTASQQO/YBecwJ9ZWwdJ9Kd6mzspw29GB5HbPLZmEdw7YAl7fwcCfxC3jLW33/wBvjOo/T/WdD3X8NyaRbnHbSY+Jtt/e/wDMrd9IXSxavQSRbRUKZae32k3e+P8ASbNYfwhsRHeABvzBJB2VYelfpDq2a8uOpgytkLBLZO7YwGSMfwwtI4n+UwDiOw232333WBav1heybv6RLtEDuyvES2Bndt5O/luH6ztzzKx7c+tVtl20rw6+g/T+Scteq6685MkaTERtWum8caa6fEfnlO9Heebi8vi8k+N0rMfkKdx8TSGukbWsRzOY1x5BxDCAT61nfWV6WItVZurlqVexQ8Fo16rA+VpmEsFm1YEzHxfcINhu2x3BZutTIsn1KxWuesJR1FpZmHz+Mns5ivG41srXkhiaLcYc2Cy5jmkt42cLZmN8l+7y3gPBwQPTJ001s7pjT+BipT15sMym2WeSSN0Uxq0PAz2bWjiAc48XPuC0miDd2U6aqs+gq2kBRnbZhkY51wyxmAtbfkucmAcfFwvDdvXvzWcXesXpnMUMaNUaZmymUxTNoHxzNZUmkDWNc+X8o1wjkMbHOieyVu7e49yqyiDfPTB0+xahymmMo7HPrPwczJ7MLZmvZO5tutYLK7i3djeGvtu70v7uXPG+s90o19XZiDJVqs1OOHHQ0jHO9j3udFYtTmTePkGkWANv7p9a1UiDdnWj6aKurxh/BqU9PxZFaZJ28kcnamz4LtwdmOQb4Me/v4x6lBdWzpBxumMwctfoz3nxV5Y6bIHxM7CabZkk57Qc3diZGDY/2rvwWsEQbE150x5/J5O7fZlcnTjtWJJYqtfIWooa0JO0MDGRPazZkYY3cAcRBJ5lZ70NdYc4/F5bD6jiv52lk2ua0vtmSzC2aF0FmPtbTnHs3METmhu3C5rz+lyr8iCxPQv1jK9DEDTupcS3OYiMbQbiKSaKNr+0ZBJDZHZzxsfzY7ia5mwA3Abw/l0udYKlbixVHTWEq4ijiMhBlK7poIDP4ZXkEsfZRweRWjL9y8hznycgS0Ah1e0QWv1J1k9LXbFXOzaUln1NThYytLPZHgMMsbi+J+7H7zCORzntLoQ8dwc3kRrvpD6eZ7er6uq8VXdTlrV68Ir2HCVsrWRyMsRS9ntxQyNlezlsQNiNjttpREFvMl1ptMyPbl26RY7UjI29nanFR8cUzW8DH+GBvbvawcgeza7YbAt7xqjph6cp8vqPF6lx0L8fcxtKpCGvc2RpsQTWZpSAO+u/wlzOE8y3ffvWmkQW4n6zOksgYcjmdHMs5uFjQJmspzwudFzjPbz7SBgPMB7Hlm/Inbc6u6OumetjdZWdUSYpsUFnwvfHUHhrYTZjDd2PlGznF4L3HZoLpHEBo2aNMIg2/gOlyvW12/Vzqczq7rt2z4GJGdtw2qk9Zre0I4OIGYOP+Ehc5Xpdrza8bq4U5hWFytZ8DMjO34YKkVUt7QDg4iYy794C0+iDbHSvriXVur4MjiYJalm3PjKtGOSRjpW22GGGB/E0cI3m4SO9WU+0H146nh6OAZIPCco9ti7wch4JUc1wHDvu1stvhI7+VaQKn3RJrR2nsvVy7KkFyWn2roobDntj7SSJ8Qk3jIPE3jJH4gH0ArsdMvSHc1RlpstcayJ744YYoIi4xV4YWcLY4y/yti8ySHf9KV37EGGIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiApLS/n1L3ut85ijVJaX8+pe91vnMQNUefXfe7PznqNX737LppZZnAB0sj5HBu4aHSOLiGgknbc+tfggIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICktL+fUve63zmKNX70LLoZYpmgF0UjJGh25aXRuDgHAEHbcetB+CIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIP//Z\n",
       "text/html": [
-       "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/f3ySpxX9oeM?rel=0\" frameborder=\"0\" allow=\"autoplay; encrypted-media\" allowfullscreen></iframe>"
+       "\n",
+       "        <iframe\n",
+       "            width=\"400\"\n",
+       "            height=\"300\"\n",
+       "            src=\"https://www.youtube.com/embed/f3ySpxX9oeM\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "        ></iframe>\n",
+       "        "
       ],
       "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "<IPython.lib.display.YouTubeVideo at 0x1ac22b686a0>"
       ]
      },
      "execution_count": 10,
@@ -731,8 +688,8 @@
     }
    ],
    "source": [
-    "from IPython.display import HTML\n",
-    "HTML('<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/f3ySpxX9oeM?rel=0\" frameborder=\"0\" allow=\"autoplay; encrypted-media\" allowfullscreen></iframe>')"
+    "from IPython.display import YouTubeVideo\n",
+    "YouTubeVideo('f3ySpxX9oeM')"
    ]
   },
   {
@@ -767,25 +724,10 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c28ab91ed86a44518c2624ae2598dd1b",
+       "model_id": "b0db905d86854153a32ee8d33cdf2921",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>IntText</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
        "IntText(value=0, description='A =')"
       ]
@@ -820,25 +762,10 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d694789ac3914fd7a194c2206ce0d9e8",
+       "model_id": "359f5498940849fcb73d43152e55eacf",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>IntText</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
        "IntText(value=0, description='B =')"
       ]
@@ -873,25 +800,10 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e4fd5c45801549ccaed7095e072a1844",
+       "model_id": "7da0e362caa644b8a220344d4786c9fc",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>IntText</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
        "IntText(value=0, description='C =')"
       ]
@@ -926,25 +838,10 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "93596635940b43098614677c6fa0d50e",
+       "model_id": "564e3362395a4b19b9743262eec4844e",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>IntText</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
        "IntText(value=0, description='D =')"
       ]
@@ -989,25 +886,10 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b6fa1e9da53f4697a5b307289367f492",
+       "model_id": "37b984639f634bf8825afffcc3ff63f9",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>IntText</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
        "IntText(value=0, description='E =')"
       ]
@@ -1044,25 +926,10 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f0ebaa970ad241b3830f22c16f4c937f",
+       "model_id": "0208e1faf00840c58c2503cdecb5c86d",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>IntText</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
        "IntText(value=0, description='F =')"
       ]
@@ -1099,25 +966,10 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "39709352ef484f43b79527a1b3a78d70",
+       "model_id": "c3c85dd800a745e8a5cfb7c9dc19ad75",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>IntText</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
        "IntText(value=0, description='G =')"
       ]
@@ -1152,25 +1004,10 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3b1a6fac219f4c1da1f7e5d628fdec3f",
+       "model_id": "69e7b1d917574ba1b10c8c8659323753",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>IntText</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
        "IntText(value=0, description='H =')"
       ]
@@ -1298,38 +1135,16 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d7423b089d6647af9896b62b06bb07e5",
+       "model_id": "6397591fe691433b937b79b097fe8b02",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>RadioButtons</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
-       "RadioButtons(description='Answer', index=1, options=('', '3 3/4', '2 1/4', '4', '1 2/3'), value='3 3/4')"
+       "RadioButtons(description='Answer', options=('', '3 3/4', '2 1/4', '4', '1 2/3'), value='')"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Correct! Great job!\n"
-     ]
     }
    ],
    "source": [
@@ -1370,38 +1185,16 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9a59dce3fad541788a55c2280f2e9a10",
+       "model_id": "41ce5be005f24c918ade209597ff12e6",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>RadioButtons</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
       "text/plain": [
-       "RadioButtons(description='Answer', index=3, options=('', '7 2/9', '2 1/2', '1 7/13', '3 1/2'), value='1 7/13')"
+       "RadioButtons(description='Answer', options=('', '7 2/9', '2 1/2', '1 7/13', '3 1/2'), value='')"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Correct! Great job!\n"
-     ]
     }
    ],
    "source": [
@@ -1444,7 +1237,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![logo](https://callysto.ca/wp-content/uploads/2018/07/Callysto-Notebook-Banner-Bottom.jpg)"
+    "![bottom](https://callysto.ca/wp-content/uploads/2018/07/Callysto-Notebook-Banner_Bottom_07.30.18.jpg)"
    ]
   }
  ],
@@ -1464,7 +1257,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the notebook file multiplication-division-fractions the bottom banner link was broken and it used an iframe (which worked, but gave an error message) rather than the newer IPython display YouTubeVideo. As well, I cleared the output that was displaying "Failed to display Jupyter Widget ...". Other than that, the notebook is unchanged.