### PR TITLE
remove pip install pytrends

### DIFF
--- a/Mathematics/StatisticsProject/AccessingData/google-search-trends.ipynb
+++ b/Mathematics/StatisticsProject/AccessingData/google-search-trends.ipynb
@@ -26,16 +26,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#install the pytrends package\n",
-    "!pip install --user pytrends                     "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from pytrends.request import TrendReq\n",
     "import pandas as pd\n",
     "\n",


### PR DESCRIPTION
pytrends has been installed in the hub for everyone so we don't need the local install code anymore.