### PR TITLE
Incorporate notebook on COVID-19 data viz

### DIFF
--- a/Science/COVID-19/world-cases/covid-19-log-curve.ipynb
+++ b/Science/COVID-19/world-cases/covid-19-log-curve.ipynb
@@ -284,7 +284,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Press the run button to display the log curve of covid cases. Use the dropdown menu to plot log curve and cumulative number of cases per country. Toggle the \"Get cumulative results\" checkbox to see how the log scale changes when we compute the daily number of cases, vs the cumulative number of cases.\n"
+    "Press the run button to display the log curve of covid cases. Enter the name of a country using the text box. This will display the log curve for raw or cumulative number of cases per country. Toggle the \"Get cumulative results\" checkbox to see how the log scale changes when we compute the daily number of cases, vs the cumulative number of cases. To see results for a different country, use the backspace or delete key to remove the country selected at first, and type the name of a new country (use the drop down menu to help you find as well). \n"
    ]
   },
   {
@@ -304,7 +304,7 @@
     "\n",
     "If in the box we select \"Canada\" and leave the box unchecked, we see that during the first few months since cases started being reported, the number of confirmed infections grew exponentially. \n",
     "\n",
-    "Using a factor of 10 (similar to Richter scale), we see that during the 2020 Spring months the growth reached a max level 3.4 in logarithmic scale. Namely, the number of infections grew by a factor of $10^{3.4}$ compared to day 1. However in the Fall months we see that the growth increased to a factor 3.6 (look at October). While this difference is not as extreme as the initial jump from 1 case to 2700, it is worth noting this indicates that during the Fall 2020, the number of reported COVID-19 infections re-entered exponential growth.\n",
+    "Using a factor of 10 (similar to Richter scale), we see that during the 2020 Spring months the growth reached a max level 3.4 in logarithmic scale. Namely, the number of infections grew by a factor of $10^{3.4}$ compared to day 1. However in the Fall months we see that the growth increased to a factor $3.6 (look at October). While this difference is not as extreme as the initial jump from 1 case to 2700, it is worth noting this indicates that during the Fall 2020, the number of reported COVID-19 infections re-entered exponential growth.\n",
     "\n",
     "While the number of reported cases in China reached a maximum log scale level 4 during Spring 2020, the log scale for the number of reported cases remained between 0 and 2.3 during the Summer and up until October 2020 (when this notebook was published). This indicates the number of confirmed reported COVID-19 infections is not increasing exponentially. \n",
     "\n",

--- a/Science/COVID-19/world-cases/covid-19-log-curve.ipynb
+++ b/Science/COVID-19/world-cases/covid-19-log-curve.ipynb
@@ -212,14 +212,14 @@
     "We can see that in Canada between the months March through May, COVID-19 spread expoentially. Between May and July, the number of cases decreased. Between August and October 2020, the number of infections is increasing exponentially once more. \n",
     "\n",
     "\n",
-    "Recall that on a logarithmic scale, numbers on the dependent variable y increases by a set factor – (though not always, this factor is usually 10). Estimating a factor (the average number of new infections a given COVID-19) in this scenario is challenging for a number of reasons. \n",
+    "Recall that on a logarithmic scale, numbers on the dependent variable y increases by a set factor – (though not always, this factor is usually 10). Estimating a factor (the average number of new infections deriving from an existing infection) in this scenario is challenging for a number of reasons. \n",
     "\n",
     "The article \"Why R0 Is Problematic for Predicting COVID-19 Spread\" Katarina Zimmer, Jul 13, 2020\n",
     " [link here](https://www.the-scientist.com/features/why-r0-is-problematic-for-predicting-covid-19-spread-67690) outlines some of those reasons.\n",
     "\n",
     "Even if we don't have the factor at which the function increases, the logarithmic scale is a great way to measure the rates of change of new confirmed infections. \n",
     "\n",
-    "When we use the logarithmic scale of COVID-19 confirmed cases, we can see when the rate of infection starts to level off. This leveling off signals that exponential growth has stopped. \n",
+    "When we use the logarithmic scale of COVID-19 confirmed cases, we can see when the rate of infection starts to level off. This leveling off signals that exponential growth has stopped. We'll use a factor of 10 to identify when rate of infection is increasing exponentially. \n",
     "\n",
     "Let's take a look at this using a graph.\n"
    ]

--- a/Science/COVID-19/world-cases/covid-19-log-curve.ipynb
+++ b/Science/COVID-19/world-cases/covid-19-log-curve.ipynb
@@ -1,0 +1,272 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Callysto.ca Banner](https://github.com/callysto/curriculum-notebooks/blob/master/callysto-notebook-banner-top.jpg?raw=true)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting Cumulative COVID-19 Cases per Country on a Logarithmic Scale\n",
+    "\n",
+    "\n",
+    "### What is a logarithmic scale?\n",
+    "\n",
+    "A logarithmic scale is a nonlinear scale often used when analyzing a large range of quantities. Instead of increasing in equal increments, each interval is increased by a factor of the base of the logarithm. Typically, a base 10 and base $e$ scale are used. In this notebook, we will use base 10. \n",
+    "\n",
+    "Let's say you have a variable $y$ which [grows exponentially](https://en.wikipedia.org/wiki/Exponential_growth), that is, \n",
+    "\n",
+    "on the first day, $y=10$, \n",
+    "\n",
+    "on the second day, $y = 100$, \n",
+    "\n",
+    "on the third day, $y = 1000$...\n",
+    "\n",
+    "What this means is that every day, the value of y will increase by a factor of ten.\n",
+    "\n",
+    "Using a logarithmic scale is useful when the largest numbers in the data are hundreds or thousands of times larger than the smallest numbers. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.express as px\n",
+    "import plotly.offline as offline \n",
+    "import plotly.graph_objs as go\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define x and y values \n",
+    "y = 1\n",
+    "y_vals = []\n",
+    "for i in range(4):\n",
+    "    y = y*10\n",
+    "    y_vals.append(y)\n",
+    "x = np.array([i for i in range(1,5)])\n",
+    "y_vals = np.array(y_vals)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot\n",
+    "px.line(x=x,y=y_vals, title='Example of exponential growth')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plot above shows exponential growth. \n",
+    "\n",
+    "Namely, each time the value of x increases by 1, the value y(x) changes by a factor of 10. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Take log base 10 of y \n",
+    "npy =  np.array(y_vals, dtype=int)\n",
+    "l_y = np.log10(npy, where=0<npy, out=np.nan*npy)\n",
+    "\n",
+    "# Plot\n",
+    "def plot_function_and_log(x,y,l_y):\n",
+    "    \"\"\"This function creates a plot of an expontential function and its logarithmic scale\"\"\"\n",
+    "    trace1 = go.Bar(x=x,y=y_vals,name=\"Function\")\n",
+    "    trace2 = go.Scatter(x=x,y=l_y,name='Log of function',yaxis='y2')\n",
+    "    layout = go.Layout(\n",
+    "        title= ('Exponential function and logarithmic scale'),\n",
+    "        yaxis=dict(title='Original function',\\\n",
+    "                   titlefont=dict(color='blue'), tickfont=dict(color='blue')),\n",
+    "        yaxis2=dict(title=' logarithmic scale', titlefont=dict(color='red'), \\\n",
+    "                    tickfont=dict(color='red'), overlaying='y', side='right'),\n",
+    "        showlegend=False)\n",
+    "    fig = go.Figure(data=[trace1,trace2],layout=layout)\n",
+    "    fig.update_yaxes(showgrid=True)\n",
+    "    fig.show()   \n",
+    "# Use function\n",
+    "plot_function_and_log(x,y_vals,l_y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the plot above the red line denotes the logarithmic scale. We are using log base 10. We see that when $x=1$, $y$ grows by a factor of 10, when $x=2$, $y$ increases by 2 factors of 10, etc. \n",
+    "\n",
+    "\n",
+    "Let's add a few more values to the function y(x), so that\n",
+    "\n",
+    "| x | y |\n",
+    "| - | - |\n",
+    "|1 | 10|\n",
+    "|2 | 100|\n",
+    "|3| 1000|\n",
+    "|4| 10000|\n",
+    "|5| 10000|\n",
+    "|6| 10000|\n",
+    "|7| 1000|\n",
+    "|8| 100|\n",
+    "|9| 10|\n",
+    "|10| 1|\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add values to x and y arrays\n",
+    "x = np.concatenate((x,np.array([5,6,7,8,9,10])), axis=0)\n",
+    "y_vals = np.concatenate((y_vals,np.array([10000,10000,1000,100,10,1])),axis=0)\n",
+    "npy =  np.array(y_vals, dtype=int)\n",
+    "l_y = np.log10(npy, where=0<npy, out=np.nan*npy)\n",
+    "# Use plot function to display function, along with log scale\n",
+    "plot_function_and_log(x,y_vals,l_y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the plot above we see that the function reaches a peak and stabilizes when x=4, and afterwards the values decrease. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### COVID-19 number of confirmed cases grow exponentially\n",
+    "\n",
+    "Since the beginning of the COVID-19 outbreak, health authorities have been tracking the total number of confirmed cases on a daily basis. During the first few months, we can see exponential growth, followed by a decrease in the number of cases. \n",
+    "\n",
+    "Logarithmic scale charts can help show how fast the number of cases is increasing. \n",
+    "\n",
+    "Let's take a look at some data[1].\n",
+    "\n",
+    "[1] Johns Hopkins University Center for Systems Science and Engineering (JHU CSSE) https://systems.jhu.edu/, for creating and maintaining https://github.com/CSSEGISandData/COVID-19 ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run -i ./scripts/download_and_parse_data.py\n",
+    "print(\"Success!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "country = \"Canada\"\n",
+    "\n",
+    "by_prov = final_confirmed[final_confirmed.index==country].set_index(\"province\").T.iloc[:-4,]\n",
+    "by_prov[\"TotalDailyCase\"] = by_prov.sum(axis=1)\n",
+    "\n",
+    "# This variable contains data on COVID 19 daily cases\n",
+    "non_cumulative_cases = by_prov.diff(axis=0)\n",
+    "t = np.linspace(0, len(non_cumulative_cases[\"TotalDailyCase\"]), len(non_cumulative_cases[\"TotalDailyCase\"]))\n",
+    "\n",
+    "trace3 = go.Scatter(x = non_cumulative_cases.index,y=non_cumulative_cases[\"TotalDailyCase\"])\n",
+    "layout = go.Layout(\n",
+    "        title= ('Daily number of COVID-19 confirmed cases in' + str(country)),\n",
+    "        yaxis=dict(title='Daily Number of  Reported Infections',\\\n",
+    "                   titlefont=dict(color='blue'), tickfont=dict(color='blue')),\n",
+    "            yaxis2=dict(title='Number of infectious members (our model)', titlefont=dict(color='red'), \\\n",
+    "                        tickfont=dict(color='red'), overlaying='y', side='right'),\n",
+    "            showlegend=False)\n",
+    "fig = go.Figure(data=[trace3],layout=layout)\n",
+    "    \n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see that in Canada between the months March through May, COVID-19 spread expoentially. Between May and July, the number of cases decreased. Between August and October 2020, the number of infections is increasing exponentially once more. \n",
+    "\n",
+    "\n",
+    "Recall that on a logarithmic scale, numbers on the dependent variable y increases by a set factor – (though not always, this factor is usually 10). Estimating a factor (the average number of new infections a given COVID-19) in this scenario is challenging for a number of reasons. \n",
+    "\n",
+    "The article \"Why R0 Is Problematic for Predicting COVID-19 Spread\" Katarina Zimmer, Jul 13, 2020\n",
+    " [link here](https://www.the-scientist.com/features/why-r0-is-problematic-for-predicting-covid-19-spread-67690) outlines some of those reasons.\n",
+    "\n",
+    "Even if we don't have the factor at which the function increases, the logarithmic scale is a great way to measure the rates of change of new confirmed infections. \n",
+    "\n",
+    "When we use the logarithmic scale of COVID-19 confirmed cases, we can see when the rate of infection starts to level off. This leveling off signals that exponential growth has stopped. \n",
+    "\n",
+    "Let's take a look at this using a graph.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Press the run button to display the log curve of covid cases. Use the dropdown menu to plot log curve and cumulative number of cases per country.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(tab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Callysto.ca License](https://github.com/callysto/curriculum-notebooks/blob/master/callysto-notebook-banner-bottom.jpg?raw=true)](https://github.com/callysto/curriculum-notebooks/blob/master/LICENSE.md)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/Science/COVID-19/world-cases/covid-19-log-curve.ipynb
+++ b/Science/COVID-19/world-cases/covid-19-log-curve.ipynb
@@ -304,7 +304,7 @@
     "\n",
     "If in the box we select \"Canada\" and leave the box unchecked, we see that during the first few months since cases started being reported, the number of confirmed infections grew exponentially. \n",
     "\n",
-    "Using a factor of 10 (similar to Richter scale), we see that during the 2020 Spring months the growth reached a max level 3.4 in logarithmic scale. Namely, the number of infections grew by a factor of $10^{3.4}$ compared to day 1. However in the Fall months we see that the growth increased to a factor $3.6 (look at October). While this difference is not as extreme as the initial jump from 1 case to 2700, it is worth noting this indicates that during the Fall 2020, the number of reported COVID-19 infections re-entered exponential growth.\n",
+    "Using a factor of 10 (similar to Richter scale), we see that during the 2020 Spring months the growth reached a max level 3.4 in logarithmic scale. Namely, the number of infections grew by a factor of $10^{3.4}$ compared to day 1. However in the Fall months we see that the growth increased to a factor $10^{3.6}$ (look at October). While this difference is not as extreme as the initial jump from 1 case to 2700, it is worth noting this indicates that during the Fall 2020, the number of reported COVID-19 infections re-entered exponential growth.\n",
     "\n",
     "While the number of reported cases in China reached a maximum log scale level 4 during Spring 2020, the log scale for the number of reported cases remained between 0 and 2.3 during the Summer and up until October 2020 (when this notebook was published). This indicates the number of confirmed reported COVID-19 infections is not increasing exponentially. \n",
     "\n",

--- a/Science/COVID-19/world-cases/covid-19-log-curve.ipynb
+++ b/Science/COVID-19/world-cases/covid-19-log-curve.ipynb
@@ -11,8 +11,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plotting Cumulative COVID-19 Cases per Country on a Logarithmic Scale\n",
+    "## Plotting Daily and Cumulative COVID-19 Cases per Country on a Logarithmic Scale\n",
     "\n",
+    "In this notebook we will explore the logarithmic scale (also known as the log scale) and we will explore how the log scale can help us determine if a country is experiencing exponential growth in the number of reported COVID-19 cases. \n",
     "\n",
     "### What is a logarithmic scale?\n",
     "\n",
@@ -28,7 +29,28 @@
     "\n",
     "What this means is that every day, the value of y will increase by a factor of ten.\n",
     "\n",
-    "Using a logarithmic scale is useful when the largest numbers in the data are hundreds or thousands of times larger than the smallest numbers. \n"
+    "Using a logarithmic scale is useful when the largest numbers in the data are hundreds or thousands of times larger than the smallest numbers. \n",
+    "\n",
+    "One application of the logarithmic scale is the Richter scale used to measure the power of an earthquake.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import YouTubeVideo\n",
+    "YouTubeVideo('RFn-IGlayAg')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's play a bit more with this scale. We will first use a \"dummy\" data set with 10 data points, then we will look at a full dataset containing the number of reported COVID-19 cases in several countries. Run the cell below to import the necessary Python functions we will need."
    ]
   },
   {
@@ -40,7 +62,15 @@
     "import plotly.express as px\n",
     "import plotly.offline as offline \n",
     "import plotly.graph_objs as go\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "print(\"Success! Imported libraries successfully\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the cell below to generate the dummy dataset. "
    ]
   },
   {
@@ -56,7 +86,15 @@
     "    y = y*10\n",
     "    y_vals.append(y)\n",
     "x = np.array([i for i in range(1,5)])\n",
-    "y_vals = np.array(y_vals)"
+    "y_vals = np.array(y_vals)\n",
+    "print(\"Values for x\",x,\"Values for y\",y_vals)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's plot. Run the cell below. "
    ]
   },
   {
@@ -75,7 +113,9 @@
    "source": [
     "The plot above shows exponential growth. \n",
     "\n",
-    "Namely, each time the value of x increases by 1, the value y(x) changes by a factor of 10. "
+    "Namely, each time the value of x increases by 1, the value y(x) changes by a factor of 10. \n",
+    "\n",
+    "Let's modify our y values to compute the log scale of y. "
    ]
   },
   {
@@ -88,6 +128,22 @@
     "npy =  np.array(y_vals, dtype=int)\n",
     "l_y = np.log10(npy, where=0<npy, out=np.nan*npy)\n",
     "\n",
+    "print(\"X values\",x,\"Log of y values\",l_y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Plot\n",
     "def plot_function_and_log(x,y,l_y):\n",
     "    \"\"\"This function creates a plot of an expontential function and its logarithmic scale\"\"\"\n",
@@ -228,7 +284,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Press the run button to display the log curve of covid cases. Use the dropdown menu to plot log curve and cumulative number of cases per country.\n"
+    "Press the run button to display the log curve of covid cases. Use the dropdown menu to plot log curve and cumulative number of cases per country. Toggle the \"Get cumulative results\" checkbox to see how the log scale changes when we compute the daily number of cases, vs the cumulative number of cases.\n"
    ]
   },
   {
@@ -238,6 +294,27 @@
    "outputs": [],
    "source": [
     "display(tab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plots above contain the daily total number of confirmed cases and deaths (marked in blue), along with the logarithmic scale associated with those cases (marked in red). \n",
+    "\n",
+    "If in the box we select \"Canada\" and leave the box unchecked, we see that during the first few months since cases started being reported, the number of confirmed infections grew exponentially. \n",
+    "\n",
+    "Using a factor of 10 (similar to Richter scale), we see that during the 2020 Spring months the growth reached a max level 3.4 in logarithmic scale. Namely, the number of infections grew by a factor of $10^{3.4}$ compared to day 1. However in the Fall months we see that the growth increased to a factor 3.6 (look at October). While this difference is not as extreme as the initial jump from 1 case to 2700, it is worth noting this indicates that during the Fall 2020, the number of reported COVID-19 infections re-entered exponential growth.\n",
+    "\n",
+    "While the number of reported cases in China reached a maximum log scale level 4 during Spring 2020, the log scale for the number of reported cases remained between 0 and 2.3 during the Summer and up until October 2020 (when this notebook was published). This indicates the number of confirmed reported COVID-19 infections is not increasing exponentially. \n",
+    "\n",
+    "___\n",
+    "\n",
+    "### Further questions\n",
+    "\n",
+    "Use the widget above to explore how the number of COVID-19 cases in countries in different parts of the world does with respect to the log scale. Can you identify countries whose growth is exponential? \n",
+    "\n",
+    "Explore the cumulative number of cases for different countries. These plots can also indicate when the number of infections is growing exponentially. Identify countries whose log scale indicates exponential growth. "
    ]
   },
   {

--- a/Science/COVID-19/world-cases/scripts/download_and_parse_data.py
+++ b/Science/COVID-19/world-cases/scripts/download_and_parse_data.py
@@ -264,7 +264,7 @@ widgets.Checkbox(
     # Button widget
     CD_button = widgets.Button(
         button_style='success',
-        description="Cumulative Case Count", 
+        description="Generate plot", 
         layout=Layout(width='15%', height='30px'),
         style=style
     )

--- a/Science/COVID-19/world-cases/scripts/download_and_parse_data.py
+++ b/Science/COVID-19/world-cases/scripts/download_and_parse_data.py
@@ -120,7 +120,7 @@ def order_dates(flat_df):
 
 
 # We will plot the log projection along with the cumulative number of cases
-def plot_log_function(country,final_df,type_case):
+def plot_log_function(country,final_df,type_case,case):
     
     latest_arr = []
     date_arr = []
@@ -129,12 +129,15 @@ def plot_log_function(country,final_df,type_case):
         latest_arr.append(final_df[final_df.index==country][item].sum())
 
     final_confirmed_red = pd.DataFrame({"Date":date_arr,"CumulativeTotal":latest_arr})
-
+    non_cumulative_cases = final_confirmed_red.diff(axis=0)
     
     
     x = final_confirmed_red.Date
-    y = final_confirmed_red.CumulativeTotal
-
+    if case==True:
+        y = final_confirmed_red.CumulativeTotal
+    else:
+        y = non_cumulative_cases.CumulativeTotal
+    
     npy = np.array(y.to_list())
     l_y = np.log10(npy, where=0<npy, out=np.nan*npy)
 
@@ -154,11 +157,11 @@ def plot_log_function(country,final_df,type_case):
     
 def draw_results(b):
     country = all_the_widgets[0].value
-    
+    case = all_the_widgets[1].value
     clear_output()
     display(tab)  ## Have to redraw the widgets
-    plot_log_function(country,final_confirmed,"confirmed")
-    plot_log_function(country,final_deaths,"fatal")
+    plot_log_function(country,final_confirmed,"confirmed",case)
+    plot_log_function(country,final_deaths,"fatal",case)
 
 if __name__ == "__main__":
 
@@ -249,7 +252,14 @@ if __name__ == "__main__":
         ensure_option=True,
         disabled=False,
         style=style
-    )]
+    ),
+widgets.Checkbox(
+    value=False,
+    description='Get cumulative results',
+    disabled=False,
+    indent=False,
+    style=style
+)]
 
     # Button widget
     CD_button = widgets.Button(


### PR DESCRIPTION
This notebook contains a logarithmic scale plot with cumulative number of cases for COVID-19 in different countries. 

The notebook provides an example of logarithmic scale, and let's the user explore the cumulative number of confirmed COVID-19 cases, along with the log scale to identify when a country's rate of infection is exponential 