### PR TITLE
Fix Broken gitpuller links

### DIFF
--- a/Mathematics/AppreciationOfMathematicsInSociety/appreciation-of-mathematics-in-society.ipynb
+++ b/Mathematics/AppreciationOfMathematicsInSociety/appreciation-of-mathematics-in-society.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "![Callysto.ca Banner](https://github.com/callysto/curriculum-notebooks/blob/master/callysto-notebook-banner-top.jpg?raw=true)\n",
     "\n",
-    "<a href=\"https://hub.callysto.ca/jupyter/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcallysto%2Fcurriculum-notebooks&branch=master&subPath=Mathematics/AppreciationOfMathematicsInSociety/appreciationofmathematicsinsociety.ipynb&depth=1\" target=\"_parent\"><img src=\"https://raw.githubusercontent.com/callysto/curriculum-notebooks/master/open-in-callysto-button.svg?sanitize=true\" width=\"123\" height=\"24\" alt=\"Open in Callysto\"/></a>"
+    "<a href=\"https://hub.callysto.ca/jupyter/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcallysto%2Fcurriculum-notebooks&branch=master&subPath=Mathematics/AppreciationOfMathematicsInSociety/appreciation-of-mathematics-in-society.ipynb&depth=1\" target=\"_parent\"><img src=\"https://raw.githubusercontent.com/callysto/curriculum-notebooks/master/open-in-callysto-button.svg?sanitize=true\" width=\"123\" height=\"24\" alt=\"Open in Callysto\"/></a>"
    ]
   },
   {
@@ -472,7 +472,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Math in Society had broken links in the "Open in Callysto
Button". This seems to have been caused by incorrect capitalization in
the old links as the repo name was changed after the gitpuller links
were generated. This commit replaces the broken links to reflect the
"new" repo name.