### PR TITLE
Heat and Temperature: fix image filepath

### DIFF
--- a/Science/HeatAndTemperature/heat-and-temperature.ipynb
+++ b/Science/HeatAndTemperature/heat-and-temperature.ipynb
@@ -393,7 +393,7 @@
     "<table>\n",
     "<tr>\n",
     "    <td><img src=\"images/OldStove.jpg\" alt=\"Old\" width=\"300\"/></td>\n",
-    "    <td><img src=\"images/modernstove2.jpg\" alt=\"New\" width=\"300\"/></td>\n",
+    "    <td><img src=\"images/modernstove.jpg\" alt=\"New\" width=\"300\"/></td>\n",
     "</tr>\n",
     "</table>\n",
     "\n",
@@ -530,7 +530,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There was a broken link to an image file. ipynb looked for a "modernstove2" but there was only "modernstove" in images.  ipynb now renders "modernstove"