### PR TITLE
Fixed issue where animations don't work in Chrome

### DIFF
--- a/Science/LightOpticalSystems/Animations/convex_inlined.html
+++ b/Science/LightOpticalSystems/Animations/convex_inlined.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html>
+ <head>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.1/p5.js"></script>
+   <script>
+    // create an animation where you can change the focal point by altering the shape of the lens
+    // the lens will be made of two arcs, then two lines on top and bottom
+    // define its boundaries in order to know when light intersects with it
+    // incoming light beams will refract at different angles depending on convexity
+
+    var m_val = 0;
+
+    function setup() {
+     createCanvas(400,400);
+     angleMode(DEGREES);
+
+    }
+
+    function draw() {
+     background(255,255,255);
+     text_box('Convex Lens',15,157,165);
+     text_box('Concave Lens',15,155,365);
+     text_box('Click buttons to change shape of lenses',10,112,200);
+     translate(200,200);
+
+     fill(41, 239, 31);
+     stroke(0);
+     ellipse(0,-20,15,15);
+     text_box('+',17,-5,-16);
+     fill(41, 239, 31);
+     stroke(0);
+     ellipse(0,20,15,15);
+     text_box('-',20,-3,26);
+
+
+     vex_lens = new convex(0,0);
+     cave_lens = new concave(0,0);
+
+     if (m_val == 0){
+      vex_lens.draw1();
+      cave_lens.draw1();
+     } else if (m_val == 1){
+      vex_lens.draw2();
+      cave_lens.draw2();
+     } else if (m_val == 2){
+      vex_lens.draw3();
+      cave_lens.draw3();
+     }
+
+    }
+
+
+    function convex(x_pos,y_pos){
+     //draw a convex lens
+     this.location = createVector(x_pos,y_pos);
+     var x = this.location.x;
+     var y = this.location.y;
+     var x1 = x - 10;
+     var x2 = x + 10;
+     var y1 = y - 150;
+     var y2 = y - 50;
+
+
+    convex.prototype.draw2 = function() {
+
+     //draw line on top and bottom
+     stroke(0);
+     line(x1, y1, x2, y1);
+     line(x1, y2, x2, y2);
+     //draw the two curves
+     noFill();
+     bezier(x1, y1, -25, -120, -25, -80, x1, y2);
+     bezier(x2, y1, 25, -120, 25, -80, x2, y2);
+
+     rays('vex',2);
+     };
+
+    convex.prototype.draw3 = function() {
+
+     //draw line on top and bottom
+     stroke(0);
+     line(x1, y1, x2, y1);
+     line(x1, y2, x2, y2);
+     //draw the two curves
+     noFill();
+     bezier(x1, y1, -30, -120, -30, -80, x1, y2);
+     bezier(x2, y1, 30, -120, 30, -80, x2, y2);
+
+     rays('vex',3);
+
+    };
+
+    convex.prototype.draw1 = function() {
+
+     //draw line on top and bottom
+     stroke(0);
+     line(x1, y1, x2, y1);
+     line(x1, y2, x2, y2);
+     //draw the two curves
+     noFill();
+     bezier(x1, y1, -20, -120, -20, -80, x1, y2);
+     bezier(x2, y1, 20, -120, 20, -80, x2, y2);
+
+     rays('vex',1);
+
+    };
+
+    }
+
+    function concave(x_pos,y_pos){
+     //draw a concave lens
+     this.location = createVector(x_pos,y_pos);
+     var x = this.location.x;
+     var y = this.location.y;
+     var x1 = x - 20;
+     var x2 = x + 20;
+     var y1 = y + 50;
+     var y2 = y + 150;
+
+
+
+
+    concave.prototype.draw2 = function() {
+
+     //draw line on top and bottom
+     stroke(0);
+     line(x1, y1, x2, y1);
+     line(x1, y2, x2, y2);
+     //draw the two curves
+     noFill();
+     bezier(x1, y1, -5, 80, -5, 120, x1, y2);
+     bezier(x2, y1, 5, 80, 5, 120, x2, y2);
+
+     rays('cave',2);
+     };
+
+     concave.prototype.draw3 = function() {
+
+     //draw line on top and bottom
+     stroke(0);
+     line(x1, y1, x + 20, y1);
+     line(x1, y2, x + 20, y2);
+     //draw the two curves
+     noFill();
+     bezier(x1, y1, 0, 80, 0, 120, x1, y2);
+     bezier(x2, y1, 0, 80, 0, 120, x2, y2);
+
+     rays('cave',3);
+     };
+
+     concave.prototype.draw1 = function() {
+
+     //draw line on top and bottom
+     stroke(0);
+     line(x1, y1, x2, y1);
+     line(x1, y2, x2, y2);
+     //draw the two curves
+     noFill();
+     bezier(x1, y1, -10, 80, -10, 120, x1, y2);
+     bezier(x2, y1, 10, 80, 10, 120, x2, y2);
+
+     rays('cave',1);
+     };
+
+    }
+
+    function rays(lens,num){
+
+     if (lens == 'vex' && num == 1){
+      //assign values
+     var q1 = -150;
+     var q2 = 0;
+     var l1 = -125;
+     var l2 = -100;
+     var l3 = -75;
+      //draw rays
+     stroke(18, 7, 237);
+     line(q1,l1,q2,l1);
+     line(q1,l2,q2,l2);
+     line(q1,l3,q2,l3);
+
+     line(q2,l1,190,-100);
+     line(q2,l2,190,-100);
+     line(q2,l3,190,-100);
+
+     } else if(lens == 'vex' && num == 2){
+      //assign values
+     var q1 = -150;
+     var q2 = 0;
+     var l1 = -125;
+     var l2 = -100;
+     var l3 = -75;
+      //draw rays
+     stroke(18, 7, 237);
+     line(q1,l1,q2,l1);
+     line(q1,l2,q2,l2);
+     line(q1,l3,q2,l3);
+
+     line(q2,l1,190,-75);
+     line(q2,l2,190,-100);
+     line(q2,l3,190,-125);
+
+
+    } else if(lens == 'vex' && num == 3){
+      //assign values
+     var q1 = -150;
+     var q2 = 0;
+     var l1 = -125;
+     var l2 = -100;
+     var l3 = -75;
+      //draw rays
+     stroke(18, 7, 237);
+     line(q1,l1,q2,l1);
+     line(q1,l2,q2,l2);
+     line(q1,l3,q2,l3);
+
+     line(q2,l1,190,-50);
+     line(q2,l2,190,-100);
+     line(q2,l3,190,-150);
+
+    }
+
+
+
+    if (lens == 'cave' && num == 1){
+      //assign values
+     var q1 = -150;
+     var q2 = 0;
+     var l1 = 125;
+     var l2 = 100;
+     var l3 = 75;
+      //draw rays
+     stroke(18, 7, 237);
+     line(q1,l1,q2,l1);
+     line(q1,l2,q2,l2);
+     line(q1,l3,q2,l3);
+
+     line(q2,l3,150,50);
+     line(q2,l2,150,100);
+     line(q2,l1,150,150);
+     } else if(lens == 'cave' && num == 2){
+      //assign values
+     var q1 = -150;
+     var q2 = 0;
+     var l1 = 125;
+     var l2 = 100;
+     var l3 = 75;
+      //draw rays
+     stroke(18, 7, 237);
+     line(q1,l1,q2,l1);
+     line(q1,l2,q2,l2);
+     line(q1,l3,q2,l3);
+
+     line(q2,l3,150,25);
+     line(q2,l2,150,100);
+     line(q2,l1,150,175);
+
+    } else if(lens == 'cave' && num == 3){
+      //assign values
+     var q1 = -150;
+     var q2 = 0;
+     var l1 = 125;
+     var l2 = 100;
+     var l3 = 75;
+      //draw rays
+     stroke(18, 7, 237);
+     line(q1,l1,q2,l1);
+     line(q1,l2,q2,l2);
+     line(q1,l3,q2,l3);
+
+     line(q2,l3,150,0);
+     line(q2,l2,150,100);
+     line(q2,l1,150,200);
+    }
+
+
+    }
+
+    function mousePressed(){
+     //change value of m_val
+     var d1 = dist(mouseX,mouseY,200,180);
+     var d2 = dist(mouseX,mouseY,200,220);
+
+     if (d1 < 20 && m_val != 2 ){
+      m_val = m_val + 1;
+     } 
+
+     if (d2 < 20 && m_val != 0){
+      m_val = m_val - 1;
+     }
+    }
+
+    function text_box(tex,size,x_pos,y_pos){
+     //create a text box 
+     textSize(size);
+     fill(0);
+     stroke(0);
+     text(tex,x_pos,y_pos);
+    }
+   </script>
+ </head>
+ <body>
+ </body>
+</html>

--- a/Science/LightOpticalSystems/Animations/reflect_inlined.html
+++ b/Science/LightOpticalSystems/Animations/reflect_inlined.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html>
+ <head>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.1/p5.js"></script>
+   <script>
+      var light;
+      var m_val = 0;
+      var x_origin = 250;
+      var y_origin = 250;
+
+      function setup() {
+      createCanvas(500,275);
+      angleMode(DEGREES);
+      }
+
+      function draw() {
+      background(255,255,255);
+      text_box('Reflection',23,200,30);
+      text_box('Normal', 14,230,70);
+      
+      //define the new origin
+      translate(x_origin,y_origin);
+      
+      //draw angle size
+        fill(255,255,255);
+        stroke(0);
+        if (mouse_angle() != 0 && m_val == 1){
+        arc(0,0,70,70,-90 - abs(mouse_angle()),-90 + abs(mouse_angle()));
+        //show angle
+        text_box((nfc(abs((mouse_angle())),1) + '\xB0'),15,-50,-50);
+        text_box((nfc(abs((mouse_angle())),1) + '\xB0'),15,35,-50);
+        }
+        
+        //draw the reflective surface
+      fill(7,189,239);
+      stroke(0);
+      rect(-150,0,300,10);
+      
+        
+      //draw normal
+      fill(0);
+      rect(-1,-170,2,170);
+      //create the flashlight
+      light = new flash(0,-150);
+      
+      rotations();
+      
+      
+      
+      
+      
+      }
+
+
+      function flash(x_pos,y_pos){
+      //create a flashlight
+      this.location = createVector(x_pos,y_pos);
+      
+      }
+      //draw the flashlight
+      flash.prototype.draw = function() {
+      var x = this.location.x;
+      var y = this.location.y;
+      //draw bottom
+      noStroke(0);
+      fill(0);
+      var bottom = rect(x-10,y-10,20,10);
+      //draw triangle
+      var tri = triangle(x-10,y-10,x,y-30,x+10,y-10);
+      //draw handle
+      var handle = rect(x-5,y-60,10,40);
+      
+      };
+
+      flash.prototype.shine1 = function(){
+      //when the mouse is clicked, turn on the flashlight
+      var x = this.location.x;
+      var y = this.location.y;
+      
+      if (m_val == 1) {
+        //mouse pressed, show beams
+        noStroke();
+        fill(239,239,7);
+        
+        rect(x-3,y,6,150);
+        ellipse(0,0,6);
+      }else if(m_val == 0){
+      }
+      
+      };
+
+      flash.prototype.shine2 = function(){
+      //when the mouse is clicked, turn on the flashlight
+      var x = this.location.x;
+      var y = this.location.y;
+      
+      if (m_val == 1) {
+        //mouse pressed, show beam
+        noStroke();
+        fill(239,239,7);
+        triangle(x-7,y,x,y-7,x+7,y);
+        rect(x-3,y,6,150);
+        ellipse(0,0,6);
+      }else if(m_val == 0){
+        
+      }
+      
+      };
+
+      function mousePressed(){
+      //change value of m_val
+      if (m_val == 0){
+        m_val = 1;
+      }else if(m_val == 1){
+        m_val = 0;
+      }
+      
+      }
+
+
+      function mouse_angle(){
+      
+      //return the angle that the mouse makes with the origin
+      
+      theta = atan((mouseX-x_origin)/(mouseY-y_origin));
+      if (abs(theta) <= 90){
+        return theta;
+      }else{
+        return 90;
+      }
+      }
+
+      function text_box(tex,size,x_pos,y_pos){
+      //create a text box 
+      textSize(size);
+      fill(0);
+      text(tex,x_pos,y_pos);
+      }
+
+
+      function rotations(){
+      //rotate the light about the new origin
+      rotate(-(mouse_angle()));
+      //draw the light
+      light.draw();
+      
+
+      //shine the light
+      light.shine1();
+      rotate(2*(mouse_angle()));
+      light.shine2();
+      rotate();
+      
+      
+      }
+
+
+
+
+
+
+
+
+   </script>
+ </head>
+ <body>
+ </body>
+</html>

--- a/Science/LightOpticalSystems/Animations/refract_inlined.html
+++ b/Science/LightOpticalSystems/Animations/refract_inlined.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html>
+ <head>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.1/p5.js"></script>
+   <script >
+    var light;
+    var m_val = 0;
+    var x_origin = 250;
+    var y_origin = 150;
+
+    function setup() {
+     createCanvas(500,300);
+     angleMode(DEGREES);
+    }
+
+    function draw() {
+     background(255,255,255);
+     text_box('Refraction',23,200,30);
+     text_box('Air',16,20,120);
+
+
+     //define the new origin
+     translate(x_origin,y_origin);
+     ref_angle = refract_angle(1.00,1.33,mouse_angle());
+
+     //draw the water
+     fill(7,189,239);
+     noStroke();
+     rect(-(width/2),0,width,(height/2));
+     text_box('Water',16,-230,30);
+
+
+     //draw angle size
+      fill(255,255,255);
+      stroke(0);
+      if (int(mouse_angle()) < 0 && m_val == 1){
+       //draw upper angle
+       arc(0,0,70,70,-90,-90 + abs((mouse_angle())));
+       //show upper angle
+       text_box((nfc(abs((mouse_angle())),1) + '\xB0'),15,35,-50);
+
+       //draw lower angle
+       fill(7,189,239);
+       stroke(0);
+       arc(0,0,70,70,90,90 + (abs((ref_angle))));
+       //show lower angle
+       text_box((nfc((abs((ref_angle))),1) + '\xB0'),15,-45,120);
+
+      } else if (int(mouse_angle()) > 0 && m_val == 1){
+       //draw upper angle
+       arc(0,0,70,70,-90 - abs((mouse_angle())),-90);
+       //show upper angle
+       text_box((nfc(abs((mouse_angle())),1) + '\xB0'),15,-50,-50);
+       //draw lower angle
+       fill(7,189,239);
+       stroke(0);
+       arc(0,0,70,70,90 - (abs(ref_angle)), 90);
+       //show lower angle
+       text_box((nfc(abs((ref_angle)),1) + '\xB0'),15,15,120);
+
+      }
+      //draw normal
+      fill(0);
+      rect(-1,-100,2,200);
+      //create the flashlight
+      light = new flash(0,-100);
+
+      rotations();
+
+
+    }
+
+
+    function flash(x_pos,y_pos){
+     //create a flashlight
+     this.location = createVector(x_pos,y_pos);
+
+    }
+     //draw the flashlight
+    flash.prototype.draw = function() {
+     var x = this.location.x;
+     var y = this.location.y;
+     //draw bottom
+     noStroke(0);
+     fill(0);
+     var bottom = rect(x-5,y-5,10,5);
+     //draw triangle
+     var tri = triangle(x-5,y-5,x,y-15,x+5,y-5);
+     //draw handle
+     var handle = rect(x-2.5,y-30,5,20);
+
+    };
+
+    flash.prototype.shine1 = function(){
+     //when the mouse is clicked, turn on the flashlight
+     var x = this.location.x;
+     var y = this.location.y;
+
+     if (m_val == 1) {
+      //mouse pressed, show beams
+      noStroke();
+      fill(239,239,7);
+      rect(x-3,y,6,100);
+      ellipse(0,0,6);
+     }else if(m_val == 0){
+     }
+
+    };
+
+    flash.prototype.shine2 = function(){
+     //when the mouse is clicked, turn on the flashlight
+     var x = this.location.x;
+     var y = this.location.y;
+
+     if (m_val == 1) {
+      //mouse pressed, show beams
+      noStroke();
+      fill(239,239,7);
+      triangle(x-7,y,x,y-7,x+7,y);
+      rect(x-3,y,6,100);
+      ellipse(0,0,6);
+     }else if(m_val == 0){
+     }
+
+    };
+
+    function mousePressed(){
+     //change value of m_val
+     if (m_val == 0){
+      m_val = 1;
+     }else if(m_val == 1){
+      m_val = 0;
+     }
+
+    }
+
+
+    function mouse_angle(){
+
+     //return the angle that the mouse makes with the origin
+
+     theta = atan((mouseX-x_origin)/(mouseY-y_origin));
+     if (abs(theta) <= 90){
+      return theta;
+     }else{
+      return 90;
+     }
+    }
+
+    function text_box(tex,size,x_pos,y_pos){
+     //create a text box 
+     textSize(size);
+     fill(0);
+     text(tex,x_pos,y_pos);
+    }
+
+
+    function refract_angle(n_1,n_2,inc_angle){
+        //get the angle of refraction for a given medium, incident angle
+        theta = asin((n_1/n_2)*(sin(inc_angle)));
+        return theta;
+    }
+
+    function rotations(){
+     //rotate the light about the new origin
+     rotate(-(mouse_angle()));
+     //draw the light
+     light.draw();
+
+
+     //shine the light
+     light.shine1();
+
+     //refract the light
+     ref_angle = refract_angle(1.00,1.33,mouse_angle());
+     rotate((180 + mouse_angle()) - ref_angle);
+     light.shine2();
+     //rotate();
+
+
+    }
+
+   </script>
+ </head>
+ <body>
+ </body>
+</html>

--- a/Science/LightOpticalSystems/light-optical-systems.ipynb
+++ b/Science/LightOpticalSystems/light-optical-systems.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,33 +113,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <iframe\n",
-       "            width=\"500\"\n",
-       "            height=\"320\"\n",
-       "            src=\"Animations/reflect_inlined.html\"\n",
-       "            frameborder=\"0\"\n",
-       "            allowfullscreen\n",
-       "        ></iframe>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<IPython.lib.display.IFrame at 0x1032195e0>"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "IFrame('Animations/reflect_inlined.html',width=500,height=320)"
    ]
@@ -179,31 +157,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <iframe\n",
-       "            width=\"520\"\n",
-       "            height=\"320\"\n",
-       "            src=\"Animations/refract_inlined.html\"\n",
-       "            frameborder=\"0\"\n",
-       "            allowfullscreen\n",
-       "        ></iframe>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<IPython.lib.display.IFrame at 0x1032f7580>"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "IFrame('Animations/refract_inlined.html',width=520,height=320)"
    ]
@@ -263,33 +219,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <iframe\n",
-       "            width=\"520\"\n",
-       "            height=\"420\"\n",
-       "            src=\"Animations/convex_inlined.html\"\n",
-       "            frameborder=\"0\"\n",
-       "            allowfullscreen\n",
-       "        ></iframe>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<IPython.lib.display.IFrame at 0x1032e0af0>"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "IFrame('Animations/convex_inlined.html',width=520,height=420)"
    ]
@@ -374,7 +308,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -388,7 +322,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.6.6"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/Science/LightOpticalSystems/light-optical-systems.ipynb
+++ b/Science/LightOpticalSystems/light-optical-systems.ipynb
@@ -11,70 +11,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import plotly as py\n",
-    "import plotly.graph_objs as go\n",
-    "import numpy as np\n",
-    "import math\n",
-    "import ipywidgets as widgets\n",
-    "from IPython.display import display, Math, Latex, HTML, IFrame\n",
-    "from astropy.table import Table, Column\n",
-    "from ipywidgets import interact, interactive\n",
-    "\n",
-    "py.offline.init_notebook_mode(connected=True)\n",
-    "%matplotlib inline\n",
-    "\n",
-    "font = {'family' : 'sans-serif',\n",
-    "        'weight' : 'normal',\n",
-    "        'size'   : 14}\n",
-    "\n",
-    "plt.rc('font', **font)\n",
-    "\n",
-    "'''Above, we are importing all the necessary modules in order to run the notebook. \n",
-    "Numpy allows us to define arrays of values for our variables to plot them\n",
-    "matplotlib is what we use to create the figures\n",
-    "the display and widgets are to make the notebook look neat\n",
-    "'''\n",
-    "\n",
-    "HTML('''<script>\n",
-    "  function code_toggle() {\n",
-    "    if (code_shown){\n",
-    "      $('div.input').hide('500');\n",
-    "      $('#toggleButton').val('Show Code')\n",
-    "    } else {\n",
-    "      $('div.input').show('500');\n",
-    "      $('#toggleButton').val('Hide Code')\n",
-    "    }\n",
-    "    code_shown = !code_shown\n",
-    "  }\n",
-    "  \n",
-    "  $( document ).ready(function(){\n",
-    "    code_shown=false;\n",
-    "    $('div.input').hide()\n",
-    "  });\n",
-    "</script>\n",
-    "<form action=\"javascript:code_toggle()\"><input type=\"submit\" id=\"toggleButton\" value=\"Show Code\"></form>''')\n",
-    "        \n",
-    "    \n"
+    "#Load function definition to help us load \n",
+    "#and display other webpages with animations which \n",
+    "#run in them.\n",
+    "from IPython.display import IFrame"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "***\n",
-    "<h1><center>  **Light and Optics** </center></h1> \n",
-    "***\n",
+    "\n",
+    "<h1><center>  Light and Optics </center></h1> \n",
+    "\n",
     "\n",
     "<img src=\"https://media.giphy.com/media/3o7OsM9vKFH2ESl0KA/giphy.gif\" alt=\"Drawing\" style=\"width: 600px;\"/>\n",
     "<center>Gif taken from https://giphy.com/gifs/fandor-sun-eclipse-3o7OsM9vKFH2ESl0KA/links, August 1st, 2018.</center>\n",
     "<center> Figure 1: For hundreds of years, scientists have tried to understand the nature of light. With advances in technology, and inventions like telescopes, we have been able to see farther than ever before. </center> \n",
     "\n",
-    "***\n",
+    "\n",
     "\n",
     "## Introduction\n",
     "\n",
@@ -95,7 +54,7 @@
     "\n",
     "Using a small slit in his window shutters, Newton passed a narrow beam of sunlight through a glass prism. The light travelled through the prism, and projected a rainbow of color on the other side!\n",
     "\n",
-    "<img src=\"http://lightingmatters.com.au/wp/wp-content/uploads/2015/09/White-Light-Prism-Experiment.jpg\" alt=\"Drawing\" style=\"width: 500px;\"/>\n",
+    "<img src=\"http://lightingmatters.com.au/wp/wp-content/uploads/2015/09/White-Light-Prism-Experiment.jpg\" alt=\"Drawing of a prism splitting white light.\" style=\"width: 500px;\"/>\n",
     "<center>Picture taken from http://lightingmatters.com.au/wp/what-is-the-colour-of-white/white-light-prism-experiment/, July 30th, 2018.</center>\n",
     "<center> Figure 2: This picture shows how a prism can create a spectrum of color. This is what Newton would have seen in 1666.</center>\n",
     "\n",
@@ -154,13 +113,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"500\"\n",
+       "            height=\"320\"\n",
+       "            src=\"Animations/reflect_inlined.html\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x1032195e0>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "IFrame('Animations/reflect.html',width=500,height=320)"
+    "IFrame('Animations/reflect_inlined.html',width=500,height=320)"
    ]
   },
   {
@@ -198,11 +179,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"520\"\n",
+       "            height=\"320\"\n",
+       "            src=\"Animations/refract_inlined.html\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x1032f7580>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "IFrame('Animations/refract.html',width=520,height=320)"
+    "IFrame('Animations/refract_inlined.html',width=520,height=320)"
    ]
   },
   {
@@ -260,11 +263,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"520\"\n",
+       "            height=\"420\"\n",
+       "            src=\"Animations/convex_inlined.html\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x1032e0af0>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "IFrame('Animations/convex.html',width=520,height=420)"
+    "IFrame('Animations/convex_inlined.html',width=520,height=420)"
    ]
   },
   {
@@ -347,7 +374,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -361,7 +388,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.5"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,


### PR DESCRIPTION
#218 Fixed issue where (in Chrome) the animations loaded in as IFrames in the notebook would not work. 

-In-lined custom javascript into html pages as new *_inlined.html files. 
-Updated notebook to reference new _inlined.html files.
-Removed unnecessary imports in top of notebook. 
-Removed '**' that appeared to be erroneous markdown in intro cell.