### PR TITLE
Remove broken image links in pricing-and-income

### DIFF
--- a/Mathematics/PricingAndIncome/pricing-and-income.ipynb
+++ b/Mathematics/PricingAndIncome/pricing-and-income.ipynb
@@ -37,16 +37,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 1. Wage and Income \n",
     "\n",
     "First, let's learn about calculating **gross income** from **hourly wage**. \n",
-    "\n",
-    "<p align=\"center\">\n",
-    "  <img src=\"https://cdn.pixabay.com/photo/2017/07/13/23/11/cinema-2502213_960_720.jpg\" width=\"400\" />\n",
-    "</p>\n",
     "\n",
     "Our friend John, is offered a job as a box office agent at a nearby movie theatre. His duties include:\n",
     "- greeting and assisting customers\n",
@@ -146,16 +143,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 2. Comission and Income\n",
     "\n",
     "Next let's learn about calculating **gross income** from **hourly wage and commissions**. \n",
-    "\n",
-    "<p align=\"center\">\n",
-    "  <img src=\"https://cdn.pixabay.com/photo/2017/06/21/20/51/tshirt-2428521_960_720.jpg\" width=\"400\" />\n",
-    "</p>\n",
     "\n",
     "The second option that John considers is working as a sales associate at a clothing retail store five bus stops from his home. His duties include:\n",
     "- greeting and welcoming customers\n",
@@ -200,16 +194,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 3. Contract and Income\n",
     "\n",
     "Third, let's learn about calculating **gross income** from **contracts**. \n",
-    "\n",
-    "<p align=\"center\">\n",
-    "  <img src=\"https://cdn.pixabay.com/photo/2017/05/16/12/14/dictionary-2317654_960_720.jpg\" width=\"400\" />\n",
-    "</p>\n",
     "\n",
     "Since John is fluent in Spanish he can work as a translator, where he would be signing contracts each time he agrees to take on a translation job. His contracts are fixed-price, meaning he will receive a certain amount for each task, depending on the number of pages he has to translate.\n",
     "\n",
@@ -365,6 +356,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -373,10 +365,6 @@
     "---\n",
     "\n",
     "John is also dreaming of buying a car. He would love a **Toyota Corolla**, which starts at a price of **$20,075** for the 2022 model.\n",
-    "\n",
-    "<p align=\"center\">\n",
-    "  <img src=\"https://cdn.pixabay.com/photo/2020/05/14/17/25/auto-5170650_1280.jpg\" width=\"400\" />\n",
-    "</p>\n",
     "\n",
     "We found that John will earn the most by working as a Box Office Agent with an annual net income of $25958.00. Assuming that he doesn't have other expenses such as housing, food, and clothing, how long would it take John to purchase his dream car?"
    ]
@@ -458,7 +446,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.10 64-bit",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -472,11 +460,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.1"
   },
   "vscode": {
    "interpreter": {
-    "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
+    "hash": "d1ca6d17674200220921376aaeb3d36cffe15ecab2470a9a5e7a456cdbf61425"
    }
   }
  },


### PR DESCRIPTION
The images were not rendering on GitHub, and the licensing was unclear, so this PR removes them.