### PR TITLE
added topics

### DIFF
--- a/SocialStudies/HansardAnalysis/hansard-analysis.ipynb
+++ b/SocialStudies/HansardAnalysis/hansard-analysis.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -11,7 +10,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -43,7 +41,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -66,7 +63,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -84,7 +80,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -107,7 +102,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -115,7 +109,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -135,7 +128,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -153,7 +145,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -170,7 +161,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -189,7 +179,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -216,7 +205,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -255,7 +243,111 @@
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###  Topics of Importance\n",
+    "We can also look at specific topics that are being addressed the most and vice versa, alongside a particular member of Parliament's topic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'pd' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[1], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m hansard_topics \u001b[38;5;241m=\u001b[39m \u001b[43mpd\u001b[49m\u001b[38;5;241m.\u001b[39mDataFrame(hansard\u001b[38;5;241m.\u001b[39mgroupby(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124msubtopic\u001b[39m\u001b[38;5;124m'\u001b[39m)[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124msubtopic\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39maggregate(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcount\u001b[39m\u001b[38;5;124m'\u001b[39m)\u001b[38;5;241m.\u001b[39mreset_index(name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcount\u001b[39m\u001b[38;5;124m'\u001b[39m))\n\u001b[1;32m      2\u001b[0m hansard_topics\u001b[38;5;241m.\u001b[39msort_values(by\u001b[38;5;241m=\u001b[39m[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcount\u001b[39m\u001b[38;5;124m'\u001b[39m], ascending\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m)\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'pd' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "hansard_topics = pd.DataFrame(hansard.groupby('subtopic')['subtopic'].aggregate('count').reset_index(name='count'))\n",
+    "hansard_topics.sort_values(by=['count'], ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topic_fig = px.pie(hansard_topics, values='count', names='subtopic', title='Number of Times a Topic was Spoken')\n",
+    "topic_fig.update_traces(textposition='inside')\n",
+    "topic_fig.update_layout(uniformtext_minsize=12, uniformtext_mode='hide')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looking at this pie chart, are certain topics <u>not</u> being addressed as much? Vice-versa, are certain topics being addressed too <u>often</u>?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also look at which <u>members of Parliament</u> speak on topics that you find <u>important</u>. In the cell below, input different `subtopic` names and see which members of Parliament talk about your particular topic!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "usr_input = input(\"Which member(s) of Parliament would you like to see, who speaks about the topic you are interested in?\\nNote: Input a topic from the one's listed in the pie-chart above with correct capitalization and spacing: \")\n",
+    "list_of_members = pd.DataFrame(hansard.loc[hansard['subtopic'] == usr_input]) # Match topic to user_input\n",
+    "list_of_members = list_of_members.drop_duplicates(subset=['speakername']) # Get rid of duplicate members who spoke on the same topic more than once\n",
+    "list_of_members = list_of_members.drop(columns=['basepk', 'hid', 'speechdate', 'pid', 'opid', 'speakerposition', 'subsubtopic', 'speechtext', 'speechtext', 'speakeroldname', 'speakerurl', 'speakerriding']).reset_index(drop=True) \n",
+    "if list_of_members.empty:\n",
+    "    print(\"No matches. Did you make sure to capitalize and space correctly?\")\n",
+    "else:\n",
+    "    display(list_of_members)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can look more in <u>depth</u> with this concept by looking at each party's most important topics using the `speakerparty` column."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colors = ['red', 'orange', 'green', 'blue', 'lightblue', 'lightseagreen']\n",
+    "for index, party in enumerate(hansard['speakerparty'].dropna().unique()):\n",
+    "    party_topics = pd.DataFrame(hansard.groupby(['subtopic', 'speakerparty'])['subtopic'].aggregate('count').reset_index(name='count'))\n",
+    "    party_topics = party_topics.sort_values(by=['count'], ascending=False)\n",
+    "    party_topics = party_topics[party_topics.speakerparty == party]\n",
+    "    title = f\"{party}'s Top 10 Topics\"\n",
+    "    fig = px.bar(party_topics.head(10), title=title, x='subtopic', y='count', labels={\"subtopic\": \"Topic\"}).update_layout(showlegend=False, height=500)\n",
+    "    fig.update_traces(marker_color=colors[index]).show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Questions:\n",
+    "\n",
+    "1. Which topics stand out between the different parties of Parliament?\n",
+    "1. Can you think of reasons why different topics are discussed more in certain parties compared to others?\n",
+    "1. What topics would you expect to be to see in certain parties that aren't seen in the top 10?"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -298,7 +390,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -321,7 +412,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -333,7 +423,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -370,7 +459,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -382,7 +470,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -439,7 +526,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -456,7 +542,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -487,7 +572,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -509,7 +593,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -531,7 +614,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -543,7 +625,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -570,7 +651,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Added a section that looks particularly at the **subtopic** column in the Hansard data frame. 
- Added a pie chart that has the _the number of times a topic was spoken_
- Added a section where users can input a particular topic and see which members of Parliament speak regarding the topic
- Added a section which looks at each party's most important topics (top 10 most spoken topics)