### PR TITLE
Res schools timeline

### DIFF
--- a/SocialStudies/GeographyResidentialSchools/timeline-of-residential-schools.ipynb
+++ b/SocialStudies/GeographyResidentialSchools/timeline-of-residential-schools.ipynb
@@ -1,0 +1,382 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Callysto.ca Banner](https://github.com/callysto/curriculum-notebooks/blob/master/callysto-notebook-banner-top.jpg?raw=true)\n",
+    "\n",
+    "<a href=\"https://hub.callysto.ca/jupyter/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcallysto%2Fcurriculum-notebooks&branch=master&subPath=SocialStudies/GeographyResidentialSchools/geography-of-residential-schools.ipynb&depth=1\" target=\"_parent\"><img src=\"https://raw.githubusercontent.com/callysto/curriculum-notebooks/master/open-in-callysto-button.svg?sanitize=true\" width=\"123\" height=\"24\" alt=\"Open in Callysto\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Canada's Residential Schools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The [Truth and Reconciliation Commission of Canada](https://www.rcaanc-cirnac.gc.ca/eng/1450124405592/1529106060525) [(TRC)](http://www.trc.ca) was created in 2008 to bring to light the experiences of Indigenous students in residential schools. In December 2015 TRC came up with the final report which gave in detail the history of residential schools, their devastating legacy, and the abuse left by these residential schools. The intention of this notebook is to raise awareness about residential schools and why it is important to be supportive and inclusive of different groups of people, languages, and cultures."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What is a residential school?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Study time in residential school](images/study-time.jpg)\n",
+    "<center>Study time in a residential school.</center>\n",
+    "<center>Source: Library and Archives Canada, PA-042133</center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Canadian government in the 19th century decided that it was responsible for providing education and care for the aboriginal people of the country in order to assimilate them into the Canadian society. The government believed that the only way to achieve this is by separating the students from their families and denying access to their own culture, language, and traditions. The government also believed that the best chance of success for these students was to learn English and to adopt Christianity and Canadian customs. This way the students will pass on the newly adopted lifestyle, language and culture to their children which would completely abolish the native traditions in a few generations.\n",
+    "\n",
+    "In order to put these into action, the Canadian government developed a policy called \"aggressive assimilation\" to be taught at the government-funded educational institutions which were church-run and provided the Indigenous children with rudimentary training in the trades and agriculture. The government believed that the children were easier to mold than adults and the concept of boarding school with compulsory attendance where children were separated from their families and communities was the best way to prepare them for life in the mainstream society.\n",
+    "\n",
+    "To learn more about residential school, please see the main notebook on the subject:\n",
+    "[Geography of Residential Schools](./geography-of-residential-schools.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Timeline of residential schools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Mohawk School](images/mohawk-school.jpg)\n",
+    "<center>The first residential school - Mohawk Institute Residential School in Ontario</center>\n",
+    "<center>Source: Library and Archives Canada</center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to understand and acknowledge the truth behind these devastating residential schools, it is important to know the locations of such schools, when they were created, and finally closed. From this, we can understand how and where it all began, which was the first residential school and how the idea quickly progressed to other provinces. Knowing the history of the place you live is important to give the respect that the place and people that belong to that place deserve and also critical to form meaningful relationships with them.\n",
+    "\n",
+    "We are going to create a map of residential school locations, similar to [this one from the National Centre for Truth and Reconciliation](https://nctr.ca/records/view-your-records/archival-map/). We have downloaded an open data set that contains [information about the residential schools](http://hesperus-wild.org/GIS_carto/IRS.html). Click on the following code cell, then click the `▶Run` button to create the map.\n",
+    "\n",
+    "The data needs to be sorted, which may take up to a minute. So please be patient while the code runs. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## First we read in the data from an online date file\n",
+    "import pandas as pd\n",
+    "rsl_data = pd.read_csv('https://raw.githubusercontent.com/callysto/data-files/main/SocialStudies/GeographyResidentialSchools/RSLlistv2.csv', encoding='latin1', skiprows=18)\n",
+    "rsl_data.replace({'Qu\\x8ebec':'Quebec'}, inplace=True)\n",
+    "\n",
+    "## We create a new the dataframe by adding a row \n",
+    "## for each year that a school is open.\n",
+    "\n",
+    "df = pd.DataFrame(columns = \\\n",
+    "            ['Name', 'Opened', 'Closed', 'Year', 'Latitude', 'Longitude','Affiliation'])\n",
+    "for i, row in rsl_data.iterrows():\n",
+    "    for year in range(row['From'],row['To']+1):\n",
+    "        df.loc[len(df.index)]= \\\n",
+    "            [row['Name'],row['From'],row['To'],year,row['Latitude'],row['Longitude'],\n",
+    "            row['Religious Affiliation']]\n",
+    " \n",
+    "# Now we sort the data\n",
+    "df.sort_values(by=['Year'], inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting\n",
+    "\n",
+    "Run the next cell to create the animation.\n",
+    "\n",
+    "Notice there was only one school from 1841 to 1860. So the animation starts off very slowly, with only one dot on the map for the first 20 years."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We now plot the map using Plotly express\n",
+    "import plotly.express as px\n",
+    "\n",
+    "latlon = {'lat':64.319832, 'lon':-96.020912}\n",
+    "\n",
+    "fig = px.scatter_geo(df, lat='Latitude', lon='Longitude', \n",
+    "                     animation_frame='Year', hover_name='Name',\n",
+    "                     hover_data={'Name':False,'Opened':True,'Closed':True,\n",
+    "                                 'Year':False,'Latitude':False,'Longitude':False},\n",
+    "                    scope='north america', center =latlon, # color='Affiliation',\n",
+    "                    title=\"Residential Schools in Canada, Timeline\")\n",
+    "fig.update_layout(\n",
+    "        geo = dict(\n",
+    "            projection_scale=2, #this is kind of like zoom\n",
+    "            center=latlon, # this will center on the point\n",
+    "        ))\n",
+    "\n",
+    "fig.show()\n",
+    "     "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## We can save this animation to disk\n",
+    "import plotly\n",
+    "plotly.offline.plot(fig, filename='test1.html')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Timeline with affiliations\n",
+    "\n",
+    "The residential schools were run by various church organizations across Canada. We can add this information to our animation, using colours to indicate which organization was in charge of which school.\n",
+    "\n",
+    "We introduce a small \"hack\" by including a dummy label for each affiliation. This is necessary to make the legend of colours appear correctly. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## We now include affliation, and show on a legend.\n",
+    "df = pd.DataFrame(columns = \\\n",
+    "            ['Name', 'Opened', 'Closed', 'Year', 'Latitude', 'Longitude','Affiliation'])\n",
+    "for i, row in rsl_data.iterrows():\n",
+    "    for year in range(row['From'],row['To']+1):\n",
+    "        df.loc[len(df.index)]= \\\n",
+    "            [row['Name'],row['From'],row['To'],year,row['Latitude'],row['Longitude'],\n",
+    "            row['Religious Affiliation']]\n",
+    "        \n",
+    "affiliations = df['Affiliation'].unique()\n",
+    "\n",
+    "# For each year, we add one row for each affliation type\n",
+    "for a in affiliations:\n",
+    "    for year in range(1841,1998):\n",
+    "        df.loc[len(df.index)]= \\\n",
+    "            ['dummy',year,year,year,85,-96,a]\n",
+    " \n",
+    "df.sort_values(by=['Year'], inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting\n",
+    "\n",
+    "Run the next cell to create the animation.\n",
+    "\n",
+    "Notice there was only one school from 1841 to 1860. So the animation starts off very slowly, with only one dot on the map for the first 20 years."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.express as px\n",
+    "\n",
+    "latlon = {'lat':64.319832, 'lon':-96.020912}\n",
+    "\n",
+    "fig = px.scatter_geo(df, lat='Latitude', lon='Longitude', \n",
+    "                     animation_frame='Year', hover_name='Name',\n",
+    "                     hover_data={'Name':False,'Opened':True,'Closed':True,\n",
+    "                                 'Year':False,'Latitude':False,'Longitude':False},\n",
+    "                    scope='north america', center =latlon, color='Affiliation',\n",
+    "                    title=\"Residential Schools in Canada with Church Affiliation\")\n",
+    "fig.update_layout(\n",
+    "        geo = dict(\n",
+    "            projection_scale=2, #this is kind of like zoom\n",
+    "            center=latlon, # this will center on the point\n",
+    "        ))\n",
+    "\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## We save the animation to disk\n",
+    "import plotly\n",
+    "plotly.offline.plot(fig, filename='test2.html')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Timeline-Map Question\n",
+    "\n",
+    "1. When did the first residential school open?\n",
+    "2. What was this school's name? Where was it located?\n",
+    "3. When did the last residential school close?\n",
+    "4. What was this last school's name? Where was it located?\n",
+    "5. What were the names of all the churches associated with residential schools?\n",
+    "\n",
+    "### Data Science Questions\n",
+    "To answer these data science questions, edit and run the code cells below.\n",
+    "\n",
+    "1. How many schools were associated with each church?\n",
+    "2. Which school was open for the longest time? How many years?\n",
+    "\n",
+    "Because programming can be pretty unforgiving with typos, here is the list of religious affiliations in this dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rsl_data['Religious Affiliation'].unique().tolist()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Count\n",
+    "We can count how many schools were affiliated with a particular church using the following code. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "affil = 'Mennonite' ## you can change this to any affiliations above\n",
+    "affil_data =rsl_data[rsl_data['Religious Affiliation']==affil]\n",
+    "print('There were', len(affil_data), 'residential schools run by', affil+':')\n",
+    "affil_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Time periods\n",
+    "\n",
+    "To see how long the schools were open, we run a loop to print out the difference between 'From' and 'To' opening years. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i, row in rsl_data.iterrows():\n",
+    "    print(row['To']-row['From'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Names\n",
+    "We can add the names to the list, to see the number of years, and the name of the school. Which one is the longest?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i, row in rsl_data.iterrows():\n",
+    "    print(row['To']-row['From'],':',row['Name'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calls to Action\n",
+    "\n",
+    "The report that the Truth and Reconciliation Commission published after listening to thousands of residential school survivors paved way to 94 Calls to Action. These are individual instructions to guide governments, communities, and faith groups down the road to reconciliation. These 94 Calls to Action can be categorized into six themes: Child Welfare, Education, Language & Culture, Health, Justice, and Reconciliation.\n",
+    "\n",
+    "CBC News has an interactive webpage called [Beyond94](https://www.cbc.ca/beyond94) dedicated to track the progress of these 94 Calls to Action. This webpage gives detailed information on all of these 94 Calls to Action and CBC's analysis on what has been acheived so for, what is in progress, and what is yet to be started.\n",
+    "\n",
+    "### Questions\n",
+    "\n",
+    "Take a look at [Beyond94](https://newsinteractives.cbc.ca/longform-single/beyond-94) to answer the following questions.\n",
+    "\n",
+    "1. How many Calls to Action are in progress? \n",
+    "2. Which Calls to Actions have already been completed?\n",
+    "3. Pick any one Call to Action under the theme \"Justice\" and summarize what it means as well as any progress.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Callysto.ca License](https://github.com/callysto/curriculum-notebooks/blob/master/callysto-notebook-banner-bottom.jpg?raw=true)](https://github.com/callysto/curriculum-notebooks/blob/master/LICENSE.md)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "d1ca6d17674200220921376aaeb3d36cffe15ecab2470a9a5e7a456cdbf61425"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Created a new Jupyter notebook for a map of the timelines of residential schools. Also includes two html files which are the Plotly outputs that can be used separately in a WordPress document, or for posting on the web. Note the html files will NOT display directly in Github so the reviewer will need to download and view in a browser. 